### PR TITLE
fix: redirect /vibe-coding to the Indonesian translation

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,7 +3,7 @@
   "redirects": [
     {
       "source": "/vibe-coding",
-      "destination": "/resources/vibecoding-demo",
+      "destination": "/id/resources/vibecoding-demo",
       "permanent": true
     }
   ],


### PR DESCRIPTION
## What changed

The `/vibe-coding` redirect in `apps/web/vercel.json` now points to `/id/resources/vibecoding-demo` instead of the English `/resources/vibecoding-demo`.

## Why

The short URL should land visitors on the Indonesian translation of the vibe coding resources page rather than the English base-locale version.

## Notes for reviewers

- The `/id/` prefix comes from Paraglide's URL locale strategy (`en` is the unprefixed base locale, `id` is prefixed); `https://chrsep.dev/id/resources/vibecoding-demo` already returns 200 in production.
- The redirect is `permanent: true` (308), so browsers that previously hit `/vibe-coding` may serve the cached English destination until their redirect cache expires. New visitors get the Indonesian page immediately after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)