### PR TITLE
Add PostHog product analytics to the web app

### DIFF
--- a/.claude/skills/integration-javascript_node/SKILL.md
+++ b/.claude/skills/integration-javascript_node/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: integration-javascript_node
+description: PostHog integration for server-side Node.js applications using posthog-node
+metadata:
+  author: PostHog
+  version: 1.30.4
+---
+
+# PostHog integration for JavaScript Node
+
+This skill helps you add PostHog analytics to JavaScript Node applications.
+
+## Workflow
+
+Follow these steps in order to complete the integration:
+
+1. `references/1-begin.md` - PostHog Setup - Begin ← **Start here**
+2. `references/2-edit.md` - PostHog Setup - Edit
+3. `references/3-revise.md` - PostHog Setup - Revise
+4. `references/4-conclude.md` - PostHog Setup - Conclusion
+
+## Reference files
+
+- `references/1-begin.md` - Start the event tracking setup process by analyzing the project and creating an event tracking plan
+- `references/2-edit.md` - Implement PostHog event tracking in the identified files, following best practices and the example project
+- `references/3-revise.md` - Review and fix any errors in the PostHog integration implementation
+- `references/4-conclude.md` - Review and fix any errors in the PostHog integration implementation
+- `references/node.md` - Node.js - docs
+- `references/posthog-node.md` - PostHog Node.js SDK
+- `references/identify-users.md` - Identify users - docs
+- `references/COMMANDMENTS.md` - Framework-specific rules the integration must follow
+
+The example project shows the target implementation pattern. Consult the documentation for API details.
+
+## Key principles
+
+- **Environment variables**: Always use environment variables for PostHog keys. Never hardcode them.
+- **Minimal changes**: Add PostHog code alongside existing integrations. Don't replace or restructure existing code.
+- **Match the example**: Your implementation should follow the example project's patterns as closely as possible.
+
+## Framework guidelines
+
+- posthog-node is the Node.js server-side SDK package name; posthog-js is browser-only, so use posthog-node on the server instead
+- Include enableExceptionAutocapture: true in the PostHog constructor options
+- Add posthog.capture() calls in route handlers for meaningful user actions – every route that creates, updates, or deletes data should track an event with contextual properties
+- Add posthog.captureException(err, distinctId) in the application's error handler (e.g., Express error middleware, Fastify setErrorHandler, Koa app.on('error'))
+- The SDK batches events and flushes asynchronously. await flush() or await shutdown() before letting that process exit. If unsure, set flushAt 1 and flushInterval 0.
+- `posthog.capture()` enqueues synchronously and returns; the batched HTTP send happens afterwards. Treat every per-request handler as short-lived even when the framework feels like a server: Next.js / Nuxt / SvelteKit / Remix route handlers, serverless and edge functions, and Lambda are torn down per invocation before the send runs. Create the client with flushAt 1 and flushInterval 0, then await the send before returning. Always use `await posthog.flush()` for a shared/singleton client, `await posthog.shutdown()` for a per-request client. Never skip the awaited flush or risk the enqueued event being silently dropped.
+- Reverse proxy is NOT needed for server-side Node.js – only client-side JavaScript needs a proxy to avoid ad blockers
+- Remember that source code is available in the node_modules directory
+- Check package.json for type checking or build scripts to validate changes
+
+## Identifying users
+
+Identify users during login and signup events. Refer to the example code and documentation for the correct identify pattern for this framework. If both frontend and backend code exist, pass the client-side session and distinct ID using `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to maintain correlation.
+
+## Error tracking
+
+Add PostHog error tracking to relevant files, particularly around critical user flows and API boundaries.

--- a/.claude/skills/integration-javascript_node/references/1-begin.md
+++ b/.claude/skills/integration-javascript_node/references/1-begin.md
@@ -1,0 +1,56 @@
+---
+title: PostHog Setup - Begin
+description: Start the event tracking setup process by analyzing the project and creating an event tracking plan
+---
+
+We're making an event tracking plan for this project.
+
+This is the first of several phases — plan the events, implement them, revise and validate changes, then conclude by creating a dashboard and writing a setup report.
+
+## Task list
+
+As soon as you've read this description and have a rough sense of the work, make a single **call `TaskCreate` immediately** before reading any reference file or beginning analysis. The user is watching the task pane and shouldn't see it sit empty.
+
+It's fine if your first list is incomplete or imprecise. Seed it with whatever high-level items you can infer from the overview above, then call `TaskCreate` again (or `TaskUpdate` to refine existing items) every time your understanding sharpens: after a phase reveals work you didn't anticipate, after planning surfaces concrete sub-items, after you hit something new. Use `TaskUpdate` to mark items `in_progress` when you start them and `completed` when you finish. Keeping the list current matters more than getting it right on the first call.
+
+Keep task titles broad and job-oriented. Describe the purpose or area of work with wording like "Planning event tracking", "Identifying users", "Installing PostHog", "Capturing events", or "Creating dashboards", not the specific files, paths, or symbols involved. Adjust the task names according to the user's project and context.
+
+Before proceeding, find any existing `posthog.capture()` code. Make note of event name formatting.
+
+From the project's file list, select between 10 and 15 files that might have interesting business value for event tracking, especially conversion and churn events. Also look for additional files related to login that could be used for identifying users, along with error handling. Read the files. If a file is already well-covered by PostHog events, replace it with another option. Do not spawn subagents.
+
+Look for opportunities to track client-side events.
+
+**IMPORTANT: Server-side events are REQUIRED** if the project includes any instrumentable server-side code. If the project has API routes (e.g., `app/api/**/route.ts`) or Server Actions, you MUST include server-side events for critical business operations like:
+
+  - Payment/checkout completion
+  - Webhook handlers
+  - Authentication endpoints
+
+Do not skip server-side events - they capture actions that cannot be tracked client-side.
+
+Create a new file with a JSON array at the root of the project: .posthog-events.json. It should include one object for each event we want to add with these exact field names: `event_name` (the event name), `event_description` (one sentence), and `file` (the file path the event goes in). The wizard reads this file to surface the plan in the UI. If events already exist, don't duplicate them; supplement them.
+
+Track actions only, not pageviews. These can be captured automatically. Exceptions can be made for "viewed"-type events that correspond to the top of a conversion funnel.
+
+As you review files, make an internal note of opportunities to identify users and catch errors. We'll need them for the next step.
+
+## Status
+
+Before beginning a phase of the setup, you will send a status message with the exact prefix '[STATUS]', as in:
+
+[STATUS] Checking project structure.
+
+Status to report in this phase:
+
+- Checking project structure
+- Verifying PostHog dependencies
+- Generating events based on project
+
+## Abort statuses
+
+If and only if the instructions have `[ABORT]` states specified, and you clearly match the conditions for an abort, emit the abort message. Do NOT attempt to exit or halt yourself — the wizard's middleware catches `[ABORT]` and terminates the run for you.
+
+---
+
+**Upon completion, continue with:** [2-edit.md](2-edit.md)

--- a/.claude/skills/integration-javascript_node/references/2-edit.md
+++ b/.claude/skills/integration-javascript_node/references/2-edit.md
@@ -1,0 +1,36 @@
+---
+title: PostHog Setup - Edit
+description: Implement PostHog event tracking in the identified files, following best practices and the example project
+---
+
+For each of the files and events noted in .posthog-events.json, make edits to capture events using PostHog. Make sure to set up any helper files needed. Carefully examine the included example project code: your implementation should match it as closely as possible. Do not spawn subagents.
+
+Use environment variables for PostHog keys. Do not hardcode PostHog keys.
+
+If a file already has existing integration code for other tools or services, don't overwrite or remove that code. Place PostHog code below it.
+
+For each event, add useful properties, and use your access to the PostHog source code to ensure correctness. You also have access to documentation about creating new events with PostHog. Consider this documentation carefully and follow it closely before adding events. Your integration should be based on documented best practices. Carefully consider how the user project's framework version may impact the correct PostHog integration approach.
+
+Remember that you can find the source code for any dependency in the node_modules directory. This may be necessary to properly populate property names. There are also example project code files available via the PostHog MCP; use these for reference.
+
+Where possible, add calls for PostHog's identify() function on the client side upon events like logins and signups. Use the contents of login and signup forms to identify users on submit. If there is server-side code, pass the client-side session and distinct ID to the server-side code to identify the user. On the server side, make sure events have a matching distinct ID where relevant. 
+
+It's essential to do this in both client code and server code, so that user behavior from both domains is easy to correlate.
+
+You should also add PostHog exception capture error tracking to these files where relevant.
+
+Remember: Do not alter the fundamental architecture of existing files. Make your additions minimal and targeted.
+
+Remember the documentation and example project resources you were provided at the beginning. Read them now.
+
+## Status
+
+Status to report in this phase:
+
+- Inserting PostHog capture code
+- A status message for each file whose edits you are planning, including a high level summary of changes
+- A status message for each file you have edited
+
+---
+
+**Upon completion, continue with:** [3-revise.md](3-revise.md)

--- a/.claude/skills/integration-javascript_node/references/3-revise.md
+++ b/.claude/skills/integration-javascript_node/references/3-revise.md
@@ -1,0 +1,22 @@
+---
+title: PostHog Setup - Revise
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Check the project for errors. Read the package.json file for any type checking or build scripts that may provide input about what to fix. Remember that you can find the source code for any dependency in the node_modules directory. Do not spawn subagents.
+
+Ensure that any components created were actually used.
+
+Once all other tasks are complete, run any linter or prettier-like scripts found in the package.json, but ONLY on the files you have edited or created during this session. Do not run formatting or linting across the entire project's codebase.
+
+## Status
+
+Status to report in this phase:
+
+- Finding and correcting errors
+- Report details of any errors you fix
+- Linting, building and prettying
+
+---
+
+**Upon completion, continue with:** [4-conclude.md](4-conclude.md)

--- a/.claude/skills/integration-javascript_node/references/4-conclude.md
+++ b/.claude/skills/integration-javascript_node/references/4-conclude.md
@@ -1,0 +1,139 @@
+---
+title: PostHog Setup - Conclusion
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Create a live PostHog dashboard named "Analytics basics (wizard)" from the events you just instrumented, then populate it with up to five insights — lead with the business-critical views: conversion funnels, churn events, and other key signals. Use the exact same event names as implemented in the code. Keep the `(wizard)` tag with that exact casing so anyone browsing PostHog can see the wizard created this dashboard, and so a quick search for `(wizard)` surfaces every wizard-created artifact in one go.
+
+## How to call PostHog MCP tools
+
+The PostHog MCP server exposes a single `exec` tool. Every PostHog operation is driven by a CLI-style command string passed in its `command` parameter — the tool may be namespaced by the host (`mcp__posthog__exec`, `mcp__posthog-wizard__exec`), but the command grammar is the same. Tool names and schemas are not predictable, so discover and inspect before you call.
+
+**Grammar** — run in this order:
+
+```text
+exec({ "command": "search <regex>" })      # find tools by name/title/description; `tools` lists them all
+exec({ "command": "info <tool_name>" })     # REQUIRED before every call — description + input schema
+exec({ "command": "schema <tool_name> <field_path>" })  # drill into a field the schema flags with a `hint`
+exec({ "command": "call <tool_name> <json_input>" })    # run the tool
+```
+
+Running `info <tool_name>` before `call <tool_name>` is mandatory, the same way you read a file before editing it. `info` returns the full schema for simple tools; for large ones it summarizes and attaches `hint` entries pointing at fields to drill into with `schema`. Dot-notation descends objects (`query.source`), array items (`series.0.properties`), and unions. Never guess the structure of a field that carries a hint — drill first.
+
+Every PostHog tool goes through `exec` this way — there is no separate named tool to call directly. The inner tool names and JSON payloads below are what you pass to `call`.
+
+**Errors** carry a suggestion and similar tool names — read it before retrying. If a name isn't found it may have been renamed; run `search <pattern>` or `tools` again to find the current one.
+
+Create the parent dashboard first with `dashboard-create`, capture its returned `id`, then attach every insight to it via `dashboards: [<id>]`:
+
+```json
+{
+  "name": "Analytics basics (wizard)",
+  "description": "Key views for the events instrumented by the PostHog wizard.",
+  "tags": ["wizard"]
+}
+```
+
+When calling `insight-create`, use these known-good query shapes — they are verified against the MCP schema, and the common variations around them are rejected:
+
+A trends insight with a breakdown (breakdowns go in `breakdownFilter.breakdowns`, an array — there is NO top-level `breakdown` field on `TrendsQuery`):
+
+```json
+{
+  "name": "Signups by plan (wizard)",
+  "dashboards": [<dashboard id from dashboard-create>],
+  "query": {
+    "kind": "InsightVizNode",
+    "source": {
+      "kind": "TrendsQuery",
+      "series": [{ "kind": "EventsNode", "event": "user_signed_up", "math": "total" }],
+      "interval": "day",
+      "dateRange": { "date_from": "-30d" },
+      "breakdownFilter": { "breakdowns": [{ "type": "event", "property": "plan" }] },
+      "trendsFilter": { "display": "ActionsBar" }
+    }
+  }
+}
+```
+
+A conversion funnel (the window fields are camelCase and live INSIDE `funnelsFilter` — not at the top level of `FunnelsQuery`, and not snake_case):
+
+```json
+{
+  "name": "Signup funnel (wizard)",
+  "dashboards": [<dashboard id from dashboard-create>],
+  "query": {
+    "kind": "InsightVizNode",
+    "source": {
+      "kind": "FunnelsQuery",
+      "series": [
+        { "kind": "EventsNode", "event": "page_viewed" },
+        { "kind": "EventsNode", "event": "user_signed_up" }
+      ],
+      "dateRange": { "date_from": "-30d" },
+      "funnelsFilter": {
+        "funnelVizType": "steps",
+        "funnelOrderType": "ordered",
+        "funnelWindowInterval": 14,
+        "funnelWindowIntervalUnit": "day"
+      }
+    }
+  }
+}
+```
+
+Valid `trendsFilter.display` values are `ActionsLineGraph`, `ActionsBar`, `ActionsAreaGraph`, `ActionsPie`, `ActionsStackedBar`, `BoldNumber`, and `ActionsTable` — names like `ActionsBarChart` or `ActionsBarGraph` are rejected. If an insight call is rejected anyway, fix the payload against these examples rather than retrying variations.
+
+Once the dashboard exists, emit its URL on its own line in your assistant message using this exact marker: `[DASHBOARD_URL] <full https url>`. The wizard parses this marker from your visible message and surfaces the link in the success summary. Mentioning the URL only in thinking or in prose without the marker means the link is dropped.
+
+Search for a file called `.posthog-events.json` and read it for available events.
+
+Do not spawn subagents.
+
+Create the file posthog-setup-report.md. It should include a summary of the integration edits, a table with the event names, event descriptions, and files where events were added, a list of links for the dashboard and insights created, and a "Verify before merging" checklist (see below). Follow this format:
+
+<wizard-report>
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of your project. [Detailed summary of changes]
+
+[table of events/descriptions/files]
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+[links]
+
+## Verify before merging
+
+[checklist]
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>
+
+For the "Verify before merging" checklist, write GitHub-style checkboxes (`- [ ] ...`) covering what the developer (or their coding agent) still needs to do to take this from "wizard finished" to "merged". Include ONLY the items that actually apply to the integration you just performed — judge each against the code you changed in this run, and drop any that don't fit. Phrase each item as a concrete, checkable action. Candidate items, with the condition for including each:
+
+- Always: "Run a full production build (the wizard only verified the files it touched) and fix any lint or type errors introduced by the generated code."
+- Always: "Run the test suite — call sites that were rewritten or instrumented may need updated mocks or fixtures."
+- If you added environment variables: "Add the exact PostHog env var names you added to `.env.example` and any monorepo/bootstrap scripts so collaborators know what to set."
+- If this integration ships a minified production browser bundle (most SPA/SSR web frameworks — e.g. Next.js, Nuxt, SvelteKit, Astro, Vite-based apps): "Wire source-map upload (`posthog-cli sourcemap` or your bundler's upload step) into CI so production stack traces de-minify."
+- If LLM analytics was set up in this run: "Trigger the LLM call path(s) you instrumented and confirm `$ai_generation` events appear in PostHog AI Observability."
+- If the app has user auth and an `identify` call was added: "Confirm the returning-visitor path also calls `identify` — a handler that only identifies on fresh login can leave returning sessions on anonymous distinct IDs."
+
+Do not invent items beyond what applies. If only the two "Always" items apply, the checklist is just those two.
+
+Then mirror the report into a shareable PostHog notebook so the user has an in-app copy to link and comment on. Call `notebooks-create` with a `title` (e.g. `PostHog setup (wizard) – <repo_name>`) and `content` set to a single markdown node wrapping the report verbatim — `{"type":"doc","content":[{"type":"ph-markdown-notebook","attrs":{"nodeId":"markdown-notebook-v2","markdown":"<the full contents of posthog-setup-report.md>"}}]}`. Take the `short_id` from the response, build the notebook URL as `<host>/project/<project_id>/notebooks/<short_id>`, and emit it on its own line so the wizard can surface it: `[NOTEBOOK_URL]` followed by that URL. Keep the local `posthog-setup-report.md` — the notebook is an extra copy, not a replacement.
+
+Upon completion, update `.posthog-events.json` so it matches the events you actually implemented, then remove it with your file tools. If removal is blocked or fails in your environment, leave the file in place and move on — the wizard host cleans it up after the run. Do not retry the removal or reach for shell commands to force it.
+
+## Status
+
+Status to report in this phase:
+
+- Configured dashboard: [insert PostHog dashboard URL]
+- Created setup report: [insert full local file path]
+- Created notebook: [insert PostHog notebook URL]

--- a/.claude/skills/integration-javascript_node/references/COMMANDMENTS.md
+++ b/.claude/skills/integration-javascript_node/references/COMMANDMENTS.md
@@ -1,0 +1,13 @@
+# Framework rules
+
+Follow these when integrating PostHog into this framework.
+
+- posthog-node is the Node.js server-side SDK package name; posthog-js is browser-only, so use posthog-node on the server instead
+- Include enableExceptionAutocapture: true in the PostHog constructor options
+- Add posthog.capture() calls in route handlers for meaningful user actions – every route that creates, updates, or deletes data should track an event with contextual properties
+- Add posthog.captureException(err, distinctId) in the application's error handler (e.g., Express error middleware, Fastify setErrorHandler, Koa app.on('error'))
+- The SDK batches events and flushes asynchronously. await flush() or await shutdown() before letting that process exit. If unsure, set flushAt 1 and flushInterval 0.
+- `posthog.capture()` enqueues synchronously and returns; the batched HTTP send happens afterwards. Treat every per-request handler as short-lived even when the framework feels like a server: Next.js / Nuxt / SvelteKit / Remix route handlers, serverless and edge functions, and Lambda are torn down per invocation before the send runs. Create the client with flushAt 1 and flushInterval 0, then await the send before returning. Always use `await posthog.flush()` for a shared/singleton client, `await posthog.shutdown()` for a per-request client. Never skip the awaited flush or risk the enqueued event being silently dropped.
+- Reverse proxy is NOT needed for server-side Node.js – only client-side JavaScript needs a proxy to avoid ad blockers
+- Remember that source code is available in the node_modules directory
+- Check package.json for type checking or build scripts to validate changes

--- a/.claude/skills/integration-javascript_node/references/identify-users.md
+++ b/.claude/skills/integration-javascript_node/references/identify-users.md
@@ -1,0 +1,272 @@
+# Identify users - Docs
+
+Linking events to specific users enables you to build a full picture of how they're using your product across different sessions, devices, and platforms.
+
+This is straightforward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js.md), as you associate events to a specific user using a `distinct_id`, which is a required argument.
+
+However, in the frontend of a [web](/docs/libraries/js/features.md#capturing-events) or [mobile app](/docs/libraries/ios.md#capturing-events), a `distinct_id` is not a required argument — PostHog's SDKs will generate an anonymous `distinct_id` for you automatically and you can capture events anonymously, provided you use the appropriate [configuration](/docs/libraries/js/features.md#capturing-anonymous-events).
+
+To link events to specific users, call `identify`:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.identify(
+  'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
+  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } // optional: set additional person properties
+);
+```
+
+### Android
+
+```kotlin
+PostHog.identify(
+    distinctId = distinctID, // Replace 'distinctID' with your user's unique identifier
+    // optional: set additional person properties
+    userProperties = mapOf(
+        "name" to "Max Hedgehog",
+        "email" to "max@hedgehogmail.com"
+    )
+)
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
+                           userProperties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional person properties
+```
+
+### React Native
+
+```jsx
+posthog.identify('distinct_id', { // Replace "distinct_id" with your user's unique identifier
+    email: 'max@hedgehogmail.com', // optional: set additional person properties
+    name: 'Max Hedgehog'
+})
+```
+
+### Dart
+
+```dart
+await Posthog().identify(
+  userId: 'distinct_id', // Replace "distinct_id" with your user's unique identifier
+  userProperties: {
+    'email': 'max@hedgehogmail.com', // optional: set additional person properties
+    'name': 'Max Hedgehog',
+  },
+);
+```
+
+Events captured after calling `identify` are identified events and this creates a person profile if one doesn't exist already.
+
+Due to the cost of processing them, anonymous events can be up to 4x cheaper than identified events, so it's recommended you only capture identified events when needed.
+
+## How identify works
+
+When a user starts browsing your website or app, PostHog automatically assigns them an **anonymous ID**, which is stored locally.
+
+Provided you've [configured persistence](/docs/libraries/js/persistence.md) to use cookies or `localStorage`, this enables us to track anonymous users – even across different sessions.
+
+By calling `identify` with a `distinct_id` of your choice (usually the user's ID in your database, or their email), you link the anonymous ID and distinct ID together.
+
+Thus, all past and future events made with that anonymous ID are now associated with the distinct ID.
+
+This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
+
+Using identify in the backend
+
+Although you can call `identify` using our backend SDKs, it is used most in frontends. This is because there is no concept of anonymous sessions in the backend SDKs, so calling `identify` only updates person profiles.
+
+## Best practices when using `identify`
+
+### 1\. Call `identify` as soon as you're able to
+
+In your frontend, you should call `identify` as soon as you're able to.
+
+Typically, this is every time your **app loads** for the first time, and directly after your **users log in**.
+
+This ensures that events sent during your users' sessions are correctly associated with them.
+
+You only need to call `identify` once per session, and you should avoid calling it multiple times unnecessarily.
+
+If you call `identify` multiple times with the same data without reloading the page in between, PostHog will ignore the subsequent calls.
+
+### 2\. Use unique strings for distinct IDs
+
+If two users have the same distinct ID, their data is merged and they are considered one user in PostHog. Two common ways this can happen are:
+
+-   Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
+-   There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
+
+PostHog also has built-in protections to stop the most common distinct ID mistakes.
+
+### 3\. Reset after logout
+
+If a user logs out on your frontend, you should call `reset()` to unlink any future events made on that device with that user.
+
+This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions.
+
+**We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
+
+You can do that like so:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.reset()
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.reset()
+```
+
+### Android
+
+```kotlin
+PostHog.reset()
+```
+
+### React Native
+
+```jsx
+posthog.reset()
+```
+
+### Dart
+
+```dart
+await Posthog().reset();
+```
+
+If you *also* want to reset the `device_id` so that the device will be considered a new device in future events, you can pass `true` as an argument:
+
+Web
+
+PostHog AI
+
+```javascript
+posthog.reset(true)
+```
+
+### 4\. Person profiles and properties
+
+You'll notice that one of the parameters in the `identify` method is a `properties` object.
+
+This enables you to set [person properties](/docs/product-analytics/person-properties.md).
+
+Whenever possible, we recommend passing in all person properties you have available each time you call identify, as this ensures their person profile on PostHog is up to date.
+
+Person properties can also be set being adding a `$set` property to a event `capture` call.
+
+See our [person properties docs](/docs/product-analytics/person-properties.md) for more details on how to work with them and best practices.
+
+### 5\. Use deep links between platforms
+
+We recommend you call `identify` [as soon as you're able](#1-call-identify-as-soon-as-youre-able), typically when a user signs up or logs in.
+
+This doesn't work if one or both platforms are unauthenticated. Some examples of such cases are:
+
+-   Onboarding and signup flows before authentication.
+-   Unauthenticated web pages redirecting to authenticated mobile apps.
+-   Authenticated web apps prompting an app download.
+
+In these cases, you can use a [deep link](https://developer.android.com/training/app-links/deep-linking) on Android and [universal links](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app) on iOS to identify users.
+
+1.  Use `posthog.get_distinct_id()` to get the current distinct ID. Even if you cannot call identify because the user is unauthenticated, this will return an anonymous distinct ID generated by PostHog.
+2.  Add the distinct ID to the deep link as query parameters, along with other properties like UTM parameters.
+3.  When the user is redirected to the app, parse the deep link and handle the following cases:
+
+-   The mobile app is already authenticated. In this case, call [`posthog.alias()`](/docs/libraries/js/features.md#alias) with the distinct ID from the web. This associates the two distinct IDs as a single person.
+-   The mobile app is unauthenticated. In this case, call [`posthog.identify()`](/docs/libraries/js/features.md#identifying-users) with the distinct ID from the web so pre-login mobile events stay connected to the web session. When the user later logs in on mobile, call `identify()` again with your canonical user ID.
+
+As long as you associate the distinct IDs with `posthog.identify()` or `posthog.alias()`, you can track events generated across platforms.
+
+Here's an example implementation for handling deep links from web to mobile:
+
+PostHog AI
+
+### iOS
+
+```swift
+import PostHog
+class DeepLinkIdentityManager {
+    static let shared = DeepLinkIdentityManager()
+    // MARK: - Deep Link Received
+    func handleDeepLink(_ url: URL, isAuthenticatedOnMobile: Bool) {
+        guard let webDistinctId = URLComponents(url: url, resolvingAgainstBaseURL: true)?
+            .queryItems?.first(where: { $0.name == "ph_distinct_id" })?.value else {
+            return
+        }
+        if isAuthenticatedOnMobile {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHogSDK.shared.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHogSDK.shared.identify(webDistinctId)
+        }
+    }
+    // MARK: - Login/Signup
+    func handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHogSDK.shared.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    func handleLogout() {
+        PostHogSDK.shared.reset()
+    }
+}
+```
+
+### Android
+
+```kotlin
+import android.net.Uri
+import com.posthog.PostHog
+object DeepLinkIdentityManager {
+    // Deep Link Received
+    fun handleDeepLink(uri: Uri, isAuthenticatedOnMobile: Boolean) {
+        val webDistinctId = uri.getQueryParameter("ph_distinct_id") ?: return
+        if (isAuthenticatedOnMobile) {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHog.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHog.identify(webDistinctId)
+        }
+    }
+    // Login/Signup
+    fun handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHog.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    fun handleLogout() {
+        PostHog.reset()
+    }
+}
+```
+
+## Further reading
+
+-   [Identifying users docs](/docs/product-analytics/identify.md)
+-   [How person processing works](/docs/how-posthog-works/ingestion-pipeline.md#2-person-processing)
+-   [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide.md)
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/integration-javascript_node/references/node.md
+++ b/.claude/skills/integration-javascript_node/references/node.md
@@ -1,0 +1,891 @@
+# Node.js - Docs
+
+If you're working with Node.js (versions 20+), the official `posthog-node` library is the simplest way to integrate your software with PostHog. This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance. And in addition to event capture, [feature flags](/docs/feature-flags.md) are supported as well.
+
+## Installation
+
+Run either `npm` or `yarn` in terminal to add it to your project:
+
+PostHog AI
+
+### npm
+
+```bash
+npm install posthog-node --save
+```
+
+### Yarn
+
+```bash
+yarn add posthog-node
+```
+
+### pnpm
+
+```bash
+pnpm add posthog-node
+```
+
+### Bun
+
+```bash
+bun add posthog-node
+```
+
+In your app, set your project token **before** making any calls.
+
+Node.js
+
+PostHog AI
+
+```javascript
+import { PostHog } from 'posthog-node'
+const client = new PostHog(
+    '<ph_project_token>',
+    { host: 'https://us.i.posthog.com' }
+)
+await client.shutdown()
+```
+
+You can find your project token and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.
+
+> **Note:** As a rule of thumb, we do not recommend hardcoding API keys or tokens. Setting it as an environment variable is preferred.
+
+## Identifying users
+
+> **Identifying users is required.** Backend events need a `distinct_id` that matches the ID your frontend uses when calling `posthog.identify()`. Without this, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay.md), [LLM traces](/docs/ai-engineering.md), or [error tracking](/docs/error-tracking.md).
+>
+> See our guide on [identifying users](/docs/getting-started/identify-users.md) for how to set this up.
+
+### Options
+
+| Variable | Description | Default value |
+| --- | --- | --- |
+| host | Your PostHog host | https://us.i.posthog.com/ |
+| flushAt | After how many capture calls we should flush the queue (in one batch) | 20 |
+| flushInterval | After how many ms we should flush the queue | 10000 |
+| personalApiKey | An optional [personal API key](/docs/api/overview.md#personal-api-keys-recommended) for evaluating feature flags locally. Note: Providing this will trigger periodic calls to the feature flags service, even if you're not using feature flags. | null |
+| featureFlagsPollingInterval | Interval in milliseconds specifying how often feature flags should be fetched from the PostHog API | 300000 |
+| requestTimeout | Timeout in milliseconds for any calls | 10000 |
+| maxCacheSize | Maximum size of cache that deduplicates $feature_flag_called calls per user. | 50000 |
+| disableGeoip | When true, disables automatic GeoIP resolution for events and feature flags. | true |
+| isServer | Controls the $is_server event property. Keep the default for server-side events. Set to false when using posthog-node from a client-like runtime, CLI, or desktop app so device OS attribution is handled normally. | true |
+| evaluationContexts | Evaluation context tags that constrain which feature flags are evaluated. When set, only flags with matching evaluation context tags (or no evaluation context tags) will be returned. This helps reduce unnecessary flag evaluations and improves performance. See [evaluation contexts documentation](/docs/feature-flags/evaluation-contexts.md) for more details. Available in version 5.23.0+. The legacy parameter evaluationEnvironments (version 5.10.0+) is also supported for backward compatibility. | undefined |
+
+> **Note:** When using PostHog in an AWS Lambda function or a similar serverless function environment, make sure you set `flushAt` to `1` and `flushInterval` to `0`. Also, remember to always call `await posthog.shutdown()` at the end to flush and send all pending events.
+
+## Capturing events
+
+You can send custom events using `capture`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+    distinctId: 'distinct_id_of_the_user',
+    event: 'user signed up',
+})
+```
+
+> **Tip:** We recommend using a `[object] [verb]` format for your event names, where `[object]` is the entity that the behavior relates to, and `[verb]` is the behavior itself. For example, `project created`, `user signed up`, or `invite sent`.
+
+### Setting event properties
+
+Optionally, you can include additional information with the event by including a [properties](/docs/data/events.md#event-properties) object:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: 'distinct_id_of_the_user',
+  event: 'user signed up',
+  properties: {
+    login_type: 'email',
+    is_free_trial: true,
+  },
+})
+```
+
+### Capturing pageviews
+
+If you're aiming for a backend-only implementation of PostHog and won't be capturing events from your frontend, you can send `$pageview` events from your backend like so:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: 'distinct_id_of_the_user',
+  event: '$pageview',
+  properties: {
+    $current_url: 'https://example.com',
+  },
+})
+```
+
+## Person profiles and properties
+
+The Node SDK captures identified events by default. These create [person profiles](/docs/data/persons.md). To set [person properties](/docs/data/user-properties.md) in these profiles, include them when capturing an event using `$set` and `$set_once`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: 'distinct_id_of_the_user',
+  event: 'movie_played',
+  properties: {
+    $set: { name: 'Max Hedgehog'  },
+    $set_once: { initial_url: '/blog' },
+  },
+})
+```
+
+For more details on the difference between `$set` and `$set_once`, see our [person properties docs](/docs/data/user-properties.md#what-is-the-difference-between-set-and-set_once).
+
+You can also use helper methods to set or remove person properties without hand-building `$set`, `$set_once`, or `$unset` payloads. See [person properties](/docs/product-analytics/person-properties.md) for examples.
+
+To capture [anonymous events](/docs/data/anonymous-vs-identified-events.md) without person profiles, set the event's `$process_person_profile` property to `false`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: 'distinct_id_of_the_user',
+  event: 'movie_played',
+  properties: {
+    $process_person_profile: false,
+  },
+})
+```
+
+## Alias
+
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.alias({
+  distinctId: 'distinct_id',
+  alias: 'alias_id',
+})
+```
+
+We strongly recommend reading our docs on [alias](/docs/data/identify.md#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
+
+## Super properties
+
+> Requires `posthog-node` version >= 5.25.0.
+
+Super properties are properties that are automatically included with every event captured by the client. Use `register` to set them:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.register({
+  app_version: '1.2.0',
+  environment: 'production',
+})
+// Both events include app_version and environment
+client.capture({
+  distinctId: 'distinct_id',
+  event: 'page_viewed',
+})
+client.capture({
+  distinctId: 'distinct_id',
+  event: 'button_clicked',
+})
+```
+
+If an event sets a property with the same key as a super property, the event's property takes precedence:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.register({ environment: 'production' })
+// This event is captured with environment='staging'
+client.capture({
+  distinctId: 'distinct_id',
+  event: 'page_viewed',
+  properties: { environment: 'staging' },
+})
+```
+
+To remove a super property, use `unregister`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.unregister('environment')
+```
+
+Super properties are **global** — they apply to every event for the lifetime of the client instance. For properties that should only apply to a specific scope (e.g. a single request or transaction), use [contexts](#contexts) instead.
+
+## Contexts
+
+> Requires `posthog-node` version >= 5.17.0.
+
+The Node SDK uses nested contexts for managing state that's shared across events. Contexts are useful for adding properties to multiple events (including exceptions) during a single user's interaction with your product.
+
+You can enter a context using `withContext`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  {
+    distinctId: 'user-123',
+    properties: { transactionId: 'abc123' }
+  },
+  () => {
+    // This event is captured with the distinct ID and properties set above
+    posthog.capture({ event: 'order_processed' })
+  }
+)
+```
+
+Contexts are persisted across function calls. If you enter one and then call a function and capture an event in the called function, it uses the context properties set in the parent context:
+
+Node.js
+
+PostHog AI
+
+```javascript
+function someFunction() {
+  // When called from `outerFunction`, this event is captured
+  // with transactionId='abc123'
+  posthog.capture({ event: 'order_processed' })
+}
+function outerFunction() {
+  posthog.withContext(
+    { properties: { transactionId: 'abc123' } },
+    () => {
+      someFunction()
+    }
+  )
+}
+```
+
+By default, each context inherits from parent contexts. To disable nesting (where child contexts is fresh and has no properties), pass `{ fresh: true }`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  {
+    properties: {
+      someKey: 'value-1',
+      someOtherKey: 'another-value'
+    }
+  },
+  () => {
+    posthog.withContext(
+      { properties: { someKey: 'value-2' } },
+      () => {
+        // Captured with someKey='value-2', someOtherKey='another-value'
+        posthog.capture({ event: 'order_processed' })
+      },
+    )
+    // Captured with someKey='value-1', someOtherKey='another-value'
+    posthog.capture({ event: 'order_completed' })
+  }
+)
+```
+
+> **Note:** Properties passed directly to `capture` calls override context state in the final event.
+
+### Identification context
+
+Contexts can be associated with a distinct ID:
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  { distinctId: 'user-123' },
+  () => {
+    // Associated with "user-123"
+    posthog.capture({ event: 'order_processed' })
+    // Overrides to "another-user"
+    posthog.capture({
+      distinctId: 'another-user',
+      event: 'order_processed'
+    })
+  }
+)
+```
+
+### Session context
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  { sessionId: 'some-session' },
+  () => {
+    // Associated with session "some-session"
+    posthog.capture({ event: 'image_uploaded' })
+    // Overrides to "next-session"
+    posthog.capture({
+      event: 'image_uploaded',
+      properties: { $sessionId: 'next-session' }
+    })
+  }
+)
+```
+
+### Custom context parameters
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  { flightNumber: 'TAC313' },
+  () => {
+    // Associated with flightNumber TAC313
+    posthog.capture({ event: 'flight_cancelled' })
+    // Overrides to PL7714
+    posthog.capture({
+      event: 'flight_cancelled',
+      properties: { flightNumber: 'PL7714' }
+    })
+  }
+)
+```
+
+## Add request context to Express
+
+> Requires `posthog-node` version >= 5.31.0.
+
+If you use Express, add request-scoped PostHog context with the built-in middleware helpers. Register `setupExpressRequestContext` before your routes so events captured during a request automatically use the incoming session and distinct ID headers. Register `setupExpressErrorHandler` after your routes if you want to send Express errors to PostHog Error Tracking.
+
+server.ts
+
+PostHog AI
+
+```typescript
+import express from 'express'
+import { PostHog, setupExpressRequestContext, setupExpressErrorHandler } from 'posthog-node'
+const app = express()
+const posthog = new PostHog('<ph_project_token>', {
+  host: 'https://us.i.posthog.com',
+})
+// Register before routes.
+setupExpressRequestContext(posthog, app)
+app.post('/checkout', (req, res) => {
+  posthog.capture({ event: 'checkout_started' })
+  res.json({ status: 'ok' })
+})
+// Optional: register after routes to capture Express errors.
+setupExpressErrorHandler(posthog, app)
+```
+
+The request context middleware reads the following incoming headers:
+
+| Header | Context property | Description |
+| --- | --- | --- |
+| x-posthog-session-id | sessionId | Links server events to a client session |
+| x-posthog-distinct-id | distinctId | Sets the event distinct ID |
+
+It also automatically adds request metadata as event properties:
+
+-   `$current_url` – the request URL
+-   `$request_method` – the HTTP method (GET, POST, etc.)
+-   `$request_path` – the request path
+-   `$user_agent` – the user agent string
+-   `$ip` – the client IP (parsed from `x-forwarded-for` if behind a proxy)
+
+Properties and `distinctId` passed directly to `capture` take precedence over request context. Tracing headers are client-controlled analytics context, not authentication or authorization. Pass an authenticated `distinctId` explicitly for security-sensitive server-side decisions.
+
+### Send headers from the client
+
+If you're using [PostHog JS](/docs/libraries/js.md) on the frontend, configure [`tracing_headers`](/docs/libraries/js/config.md#tracing-headers) for your Express backend hostname so browser requests include `X-POSTHOG-SESSION-ID` and `X-POSTHOG-DISTINCT-ID`, which the Express middleware reads automatically.
+
+## Feature flags
+
+PostHog's [feature flags](/docs/feature-flags.md) enable you to safely deploy and roll back new features as well as target specific users and groups with them.
+
+There are two steps to implement feature flags in Node:
+
+### Step 1: Evaluate flags once
+
+Call `client.evaluateFlags()` once for the user, then read values from the returned snapshot.
+
+#### Boolean feature flags
+
+Node.js
+
+PostHog AI
+
+```javascript
+const flags = await client.evaluateFlags('distinct_id_of_your_user')
+if (flags.isEnabled('flag-key')) {
+    // Do something differently for this user
+    // Optional: fetch the payload
+    const matchedFlagPayload = flags.getFlagPayload('flag-key')
+}
+```
+
+#### Multivariate feature flags
+
+Node.js
+
+PostHog AI
+
+```javascript
+const flags = await client.evaluateFlags('distinct_id_of_your_user')
+const enabledVariant = flags.getFlag('flag-key')
+if (enabledVariant === 'variant-key') { // replace 'variant-key' with the key of your variant
+    // Do something differently for this user
+    // Optional: fetch the payload
+    const matchedFlagPayload = flags.getFlagPayload('flag-key')
+}
+```
+
+`flags.getFlag()` returns the variant string for multivariate flags, `true` for enabled boolean flags, `false` for disabled flags, and `undefined` when the flag wasn't returned by the evaluation.
+
+> **Note:** `client.isFeatureEnabled()`, `client.getFeatureFlag()`, `client.getFeatureFlagPayload()`, and `capture({ sendFeatureFlags: true })` still work during the migration period, but they're deprecated. Prefer `evaluateFlags()` for new code.
+
+### Step 2: Include feature flag information when capturing events
+
+If you want use your feature flag to breakdown or filter events in your [insights](/docs/product-analytics/insights.md), you'll need to include feature flag information in those events. This ensures that the feature flag value is attributed correctly to the event.
+
+> **Note:** This step is only required for events captured using our server-side SDKs or [API](/docs/api.md).
+
+There are two methods you can use to include feature flag information in your events:
+
+#### Method 1: Pass the evaluated flags snapshot to `capture()`
+
+Pass the same `flags` object that you used for branching. This attaches the exact flag values from that evaluation and doesn't make another `/flags` request.
+
+Node.js
+
+PostHog AI
+
+```javascript
+const flags = await client.evaluateFlags('distinct_id_of_your_user')
+if (flags.isEnabled('flag-key')) {
+    // Do something differently for this user
+}
+client.capture({
+    distinctId: 'distinct_id_of_your_user',
+    event: 'event_name',
+    flags,
+})
+```
+
+By default, this attaches every flag in the snapshot using `$feature/<flag-key>` properties and `$active_feature_flags`.
+
+To reduce event property bloat, pass a filtered snapshot:
+
+Node.js
+
+PostHog AI
+
+```javascript
+// Attach only flags accessed with isEnabled() or getFlag() before this call
+client.capture({
+    distinctId: 'distinct_id_of_your_user',
+    event: 'event_name',
+    flags: flags.onlyAccessed(),
+})
+// Attach only specific flags
+client.capture({
+    distinctId: 'distinct_id_of_your_user',
+    event: 'event_name',
+    flags: flags.only(['checkout-flow', 'new-dashboard']),
+})
+```
+
+`onlyAccessed()` is order-dependent. If you call it before accessing any flags with `isEnabled()` or `getFlag()`, no feature flag properties are attached.
+
+#### Method 2: Include the `$feature/feature_flag_name` property manually
+
+In the event properties, include `$feature/feature_flag_name: variant_key`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+    distinctId: 'distinct_id_of_your_user',
+    event: 'event_name',
+    properties: {
+        // Replace feature-flag-key with your flag key and 'variant-key' with the key of your variant
+        '$feature/feature-flag-key': 'variant-key',
+    },
+})
+```
+
+### Evaluating only specific flags
+
+By default, `evaluateFlags()` evaluates every flag for the user. If you only need a few flags, pass `flagKeys` to request only those flags:
+
+Node.js
+
+PostHog AI
+
+```javascript
+const flags = await client.evaluateFlags('distinct_id_of_your_user', {
+    flagKeys: ['checkout-flow', 'new-dashboard'],
+})
+```
+
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enables PostHog to know when a flag was accessed by a user and provide [analytics and insights](/docs/product-analytics/insights.md) on the flag. With `evaluateFlags()`, the SDK sends this event when you call `flags.isEnabled()` or `flags.getFlag()` for a flag.
+
+The SDK deduplicates these events per `(distinct_id, flag, value)` in a local cache. If you reinitialize the PostHog client, the cache resets and `$feature_flag_called` events may be sent again. PostHog handles duplicates, so duplicate `$feature_flag_called` events don't affect your analytics.
+
+`flags.getFlagPayload()` doesn't send `$feature_flag_called` events and doesn't count as an access for `onlyAccessed()`.
+
+### Advanced: Overriding server properties
+
+Sometimes, you may want to evaluate feature flags using [person properties](/docs/product-analytics/person-properties.md), [groups](/docs/product-analytics/group-analytics.md), or group properties that haven't been ingested yet, or were set incorrectly earlier.
+
+You can provide properties to evaluate the flag with by using the `person properties`, `groups`, and `group properties` arguments. PostHog will then use these values to evaluate the flag, instead of any properties currently stored on your PostHog server.
+
+For example:
+
+Node.js
+
+PostHog AI
+
+```javascript
+const flags = await client.evaluateFlags('distinct_id_of_the_user', {
+    personProperties: {
+        property_name: 'value',
+    },
+    groups: {
+        your_group_type: 'your_group_id',
+        another_group_type: 'your_group_id',
+    },
+    groupProperties: {
+        your_group_type: {
+            group_property_name: 'value',
+        },
+        another_group_type: {
+            group_property_name: 'value',
+        },
+    },
+})
+if (flags.isEnabled('flag-key')) {
+    // Do something differently for this user
+}
+```
+
+### Overriding GeoIP properties
+
+By default, a user's GeoIP properties are set using the IP address they use to capture events on the frontend. You may want to override the these properties when evaluating feature flags. A common reason to do this is when you're not using PostHog on your frontend, so the user has no GeoIP properties.
+
+You can override GeoIP properties by including them in the `person_properties` parameter when evaluating feature flags. This is useful when you're evaluating flags on your backend and want to use the client's location instead of your server's location.
+
+The following GeoIP properties can be overridden:
+
+-   `$geoip_country_code`
+-   `$geoip_country_name`
+-   `$geoip_city_name`
+-   `$geoip_city_confidence`
+-   `$geoip_continent_code`
+-   `$geoip_continent_name`
+-   `$geoip_latitude`
+-   `$geoip_longitude`
+-   `$geoip_postal_code`
+-   `$geoip_subdivision_1_code`
+-   `$geoip_subdivision_1_name`
+-   `$geoip_subdivision_2_code`
+-   `$geoip_subdivision_2_name`
+-   `$geoip_subdivision_3_code`
+-   `$geoip_subdivision_3_name`
+-   `$geoip_time_zone`
+
+Simply include any of these properties in the `person_properties` parameter alongside your other person properties when calling feature flags.
+
+### Request timeout
+
+You can configure the `featureFlagsRequestTimeoutMs` parameter when initializing your PostHog client to set a flag request timeout. This helps prevent your code from being blocked if PostHog's servers are too slow to respond. By default, this is set to 3 seconds.
+
+JavaScript
+
+PostHog AI
+
+```javascript
+const client = new PostHog('<ph_project_token>', {
+    host: 'https://us.i.posthog.com',
+    featureFlagsRequestTimeoutMs: 3000, // Time in milliseconds. Defaults to 3000 (3 seconds).
+})
+```
+
+> **Note:** For remote config flags, see the [remote config documentation](/docs/feature-flags/remote-config.md). Remote config requires the [Feature Flags secure API key](/docs/feature-flags/remote-config.md#step-1-find-your-feature-flags-secure-api-key) passed as the `personalApiKey` option.
+
+### Local evaluation
+
+Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
+
+It is best practice to use local evaluation flags when possible, since this enables you to resolve flags faster and with fewer API calls.
+
+For details on how to implement local evaluation, see our [local evaluation guide](/docs/feature-flags/local-evaluation.md).
+
+Node.js
+
+PostHog AI
+
+```javascript
+const flags = await client.evaluateFlags('user distinct id', {
+    groups: { organization: 'google' },
+    groupProperties: { organization: { is_authorized: true } },
+})
+const flagValue = flags.getFlag('flag-key')
+```
+
+#### Reloading feature flags
+
+When initializing PostHog, you can configure the interval at which feature flags are polled (fetched from the server). However, if you need to force a reload, you can use `reloadFeatureFlags`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+await client.reloadFeatureFlags()
+// Do something with feature flags here
+```
+
+#### Distributed environments
+
+In multi-worker or edge environments, you can implement custom caching for flag definitions using Redis, Cloudflare KV, or other storage backends. This enables sharing definitions across workers and coordinating fetches. See our guide for [local evaluation in distributed environments](/docs/feature-flags/local-evaluation/distributed-environments?tab=Node.js.md) for details.
+
+## Experiments (A/B tests)
+
+Since [experiments](/docs/experiments/start-here.md) use feature flags, the code for running an experiment is very similar to the feature flags code:
+
+Node.js
+
+PostHog AI
+
+```javascript
+const flags = await client.evaluateFlags('user_distinct_id')
+const variant = flags.getFlag('experiment-feature-flag-key')
+if (variant === 'variant-name') {
+  // Do something
+}
+```
+
+It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags.md).
+
+## Group analytics
+
+Group analytics enable you to associate an event with a group (e.g. teams, organizations, etc.). Read the [group analytics guide](/docs/product-analytics/group-analytics.md) for more information.
+
+To create a group or update its properties, use `groupIdentify`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.groupIdentify({
+  groupType: 'company',
+  groupKey: 'company_id_in_your_db',
+  properties: {
+    name: 'Awesome Inc',
+    employees: 11,
+  },
+  // optional distinct ID to associate event with an existing person
+  distinctId: 'xyz'
+})
+```
+
+`name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID is used instead.
+
+If the optional `distinctId` parameter is not provided in the group identify call, it defaults to `${groupType}_${groupKey}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior results in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinctId`, such as `group_identifier`.
+
+Once a group is created, you can use the `capture` method and pass in the `groups` parameter to capture an event with group analytics.
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  event: 'some_event',
+  distinctId: 'user_distinct_id',
+  groups: { company: 'company_id_in_your_db' },
+})
+```
+
+## GeoIP properties
+
+Before `posthog-node` v3.0, we added GeoIP properties to all incoming events by default. We also used these properties for feature flag evaluation, based on the IP address of the request. This isn't ideal since they are created based on your server IP address, rather than the user's, leading to incorrect location resolution.
+
+As of `posthog-node` v3.0, the default now is to disregard the server IP, not add the GeoIP properties, and not use the values for feature flag evaluations.
+
+You can go back to previous behavior by setting `disableGeoip` to false in your initialization:
+
+Node.js
+
+PostHog AI
+
+```javascript
+const posthog = new PostHog('<ph_project_token>', {
+  host: 'https://us.i.posthog.com',
+  disableGeoip: false
+})
+```
+
+The list of properties that this overrides:
+
+1.  `$geoip_city_name`
+2.  `$geoip_country_name`
+3.  `$geoip_country_code`
+4.  `$geoip_continent_name`
+5.  `$geoip_continent_code`
+6.  `$geoip_postal_code`
+7.  `$geoip_time_zone`
+
+You can also explicitly chose to enable or disable GeoIP for a single capture request like so:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: distinctId,
+  event: 'your_event',
+  disableGeoip: `true`,
+})
+```
+
+## Shutdown
+
+You should call `shutdown` on your program's exit to exit cleanly:
+
+Node.js
+
+PostHog AI
+
+```javascript
+// Stop pending pollers and flush any remaining events
+await client.shutdown()
+```
+
+## Debug mode
+
+If you're not seeing the expected events being captured, the feature flags being evaluated, or the surveys being shown, you can enable debug mode to see what's happening.
+
+You can enable debug mode by calling the `debug()` method in your code. This will enable verbose logs about the inner workings of the SDK.
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.debug()
+```
+
+## Handling errors thrown by the SDK
+
+If you are experiencing issues with the SDK it could be a number of things from an incorrectly configured API key, to some other network related issues.
+
+The SDK does not throw errors for things happening in the background to ensure it doesn't affect your process. You can however hook into the errors to get more information:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.on("error", (err) => {
+  // Whatever handling you want
+  console.error("PostHog had an error!", err)
+})
+```
+
+## Short-lived processes like serverless environments
+
+The Node SDK is designed to queue and batch requests in the background to optimize API calls and network time. As serverless environments like AWS Lambda or [Vercel Functions](/docs/libraries/vercel.md) are short-lived, we provide a few options to ensure all events are captured.
+
+First, we recommend using the `captureImmediate` method instead of `capture` to ensure the event is captured before the function shuts down. It guarantees the HTTP request finishes before your function continues (or shuts down).
+
+Second, we recommend setting `flushAt` to `1` and `flushInterval` to `0` to ensure the events are sent immediately. These set the queue to flush immediately, both in terms of events and time.
+
+Third, we provide a method `shutdown()` which can be awaited to ensure all queued events are sent to the API. For example:
+
+Node.js
+
+PostHog AI
+
+```javascript
+export const handler() {
+  client.capture({
+    distinctId: 'distinct_id_of_the_user',
+    event: 'thing_happened'
+  })
+  client.capture({
+    distinctId: 'distinct_id_of_the_user',
+    event: 'other_thing_happened'
+  })
+  // So far 2 events are queued but not sent
+  // Calling shutdown, flushed the queue but batched into 1 API call for maximum efficiency
+  await client.shutdown()
+}
+```
+
+This is also useful for shutting down a standard Node.js app.
+
+## AI Observability
+
+You can capture LLM usage and performance data by combining the `posthog-node` and `@posthog/ai` libraries. These work with LLM providers like OpenAI and Vercel's AI SDKs. Learn more in our [AI Observability docs](/docs/ai-observability.md).
+
+## Error tracking
+
+You can capture errors using the `posthog-node` library. This enables you to see stack traces, source code, and watch associated session recordings to improve your application stability. Learn more in our [error tracking docs](/docs/error-tracking/installation/node.md).
+
+## Upgrading from V1 to V2
+
+V2.x.x of the Node.js library is completely rewritten in Typescript and is based on a new JS core shared with other JavaScript based libraries with the goal of ensuring new features and fixes reach the different libraries at the same pace.
+
+With the release of V2, the API was kept mostly the same but with some small changes and deprecations:
+
+1.  The minimum PostHog version requirement is 1.38
+2.  The `callback` parameter passed as an optional last argument to most of the methods is no longer supported
+3.  The method signature for `isFeatureEnabled` and `getFeatureFlag` is slightly modified. See the above documentation for each method for more details.
+4.  For specific changes, [see the CHANGELOG](https://github.com/PostHog/posthog-js/blob/main/packages/node/CHANGELOG.md)
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/integration-javascript_node/references/posthog-node.md
+++ b/.claude/skills/integration-javascript_node/references/posthog-node.md
@@ -1,0 +1,1538 @@
+# PostHog Node.js SDK
+
+**SDK Version:** <version>
+
+PostHog Node.js SDK allows you to capture events and send them to PostHog from your Node.js applications.
+
+## Categories
+
+- Initialization
+- Identification
+- Capture
+- Error tracking
+- Privacy
+- Feature flags
+- Context
+
+## PostHog
+
+### Other methods
+
+#### getLibraryId()
+
+**Release Tag:** public
+
+### Returns
+
+- `string`
+
+### Examples
+
+```node
+// Generated example for getLibraryId
+posthog.getLibraryId();
+```
+
+---
+
+#### enterContext()
+
+**Release Tag:** public
+
+Set context without a callback wrapper.
+Uses `AsyncLocalStorage.enterWith()` to attach context to the current async execution context. The context lives until that async context ends.
+Must be called in the same async scope that makes PostHog calls. Calling this outside a request-scoped async context will leak context across unrelated work. Prefer `withContext()` when you can wrap code in a callback — it creates an isolated scope that cleans up automatically.
+
+### Parameters
+
+- **`data`** (`Partial<ContextData>`) - Context data to apply (distinctId, sessionId, properties)
+- **`options?`** (`ContextOptions`) - Context options (fresh: true to start with clean context instead of inheriting)
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+// Generated example for enterContext
+posthog.enterContext();
+```
+
+---
+
+#### flush()
+
+**Release Tag:** public
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for flush
+posthog.flush();
+```
+
+---
+
+#### prepareEventMessage()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`props`** (`EventMessage`)
+
+### Returns
+
+- `Promise<{
+        distinctId: string;
+        event: string;
+        properties: PostHogEventProperties;
+        options: PostHogCaptureOptions;
+    }>`
+
+### Examples
+
+```node
+// Generated example for prepareEventMessage
+posthog.prepareEventMessage();
+```
+
+---
+
+#### fetch()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`url`** (`string`)
+- **`options`** (`PostHogFetchOptions`)
+
+### Returns
+
+- `Promise<PostHogFetchResponse>`
+
+### Examples
+
+```node
+// Generated example for fetch
+posthog.fetch();
+```
+
+---
+
+#### getSurveysStateless()
+
+**Release Tag:** public
+
+* ** SURVEYS *
+
+### Returns
+
+- `Promise<SurveyResponse['surveys']>`
+
+### Examples
+
+```node
+// Generated example for getSurveysStateless
+posthog.getSurveysStateless();
+```
+
+---
+
+#### on()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`event`** (`string`)
+- **`cb`** (`(...args: any[]) => void`)
+
+### Returns
+
+- `() => void`
+
+### Examples
+
+```node
+// Generated example for on
+posthog.on();
+```
+
+---
+
+#### optIn()
+
+**Release Tag:** public
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for optIn
+posthog.optIn();
+```
+
+---
+
+#### optOut()
+
+**Release Tag:** public
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for optOut
+posthog.optOut();
+```
+
+---
+
+#### register()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`properties`** (`PostHogEventProperties`)
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for register
+posthog.register();
+```
+
+---
+
+#### unregister()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`property`** (`string`)
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for unregister
+posthog.unregister();
+```
+
+---
+
+### Initialization methods
+
+#### PostHog()
+
+**Release Tag:** public
+
+Initialize a new PostHog client instance.
+
+### Parameters
+
+- **`apiKey`** (`string`) - Your PostHog project API key
+- **`options?`** (`PostHogOptions`) - Configuration options for the client
+
+### Returns
+
+- `any`
+
+### Examples
+
+#### Basic initialization
+
+```node
+// Basic initialization
+const client = new PostHogBackendClient(
+  'your-api-key',
+  { host: 'https://app.posthog.com' }
+)
+```
+
+#### With a secret key (Personal API Key or Project Secret API Key) for local evaluation
+
+```node
+// With a secret key (Personal API Key or Project Secret API Key) for local evaluation
+const client = new PostHogBackendClient(
+  'your-api-key',
+  {
+    host: 'https://app.posthog.com',
+    secretKey: 'your-secret-key'
+  }
+)
+```
+
+---
+
+#### debug()
+
+**Release Tag:** public
+
+Enable or disable debug logging.
+
+### Parameters
+
+- **`enabled?`** (`boolean`) - Whether to enable debug logging
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Enable debug logging
+
+```node
+// Enable debug logging
+client.debug(true)
+```
+
+#### Disable debug logging
+
+```node
+// Disable debug logging
+client.debug(false)
+```
+
+---
+
+#### getLibraryVersion()
+
+**Release Tag:** public
+
+Get the library version from package.json.
+
+### Returns
+
+- `string`
+
+### Examples
+
+```node
+// Get version
+const version = client.getLibraryVersion()
+console.log(`Using PostHog SDK version: ${version}`)
+```
+
+---
+
+#### getPersistedProperty()
+
+**Release Tag:** public
+
+Get a persisted property value from memory storage.
+
+### Parameters
+
+- **`key`** (`PostHogPersistedProperty`) - The property key to retrieve
+
+### Returns
+
+**Union of:**
+- `any`
+- `undefined`
+
+### Examples
+
+#### Get user ID
+
+```node
+// Get user ID
+const userId = client.getPersistedProperty('userId')
+```
+
+#### Get session ID
+
+```node
+// Get session ID
+const sessionId = client.getPersistedProperty('sessionId')
+```
+
+---
+
+#### setPersistedProperty()
+
+**Release Tag:** public
+
+Set a persisted property value in memory storage.
+
+### Parameters
+
+- **`key`** (`PostHogPersistedProperty`) - The property key to set
+- **`value`** (`any | null`) - The value to store (null to remove)
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Set user ID
+
+```node
+// Set user ID
+client.setPersistedProperty('userId', 'user_123')
+```
+
+#### Set session ID
+
+```node
+// Set session ID
+client.setPersistedProperty('sessionId', 'session_456')
+```
+
+---
+
+#### shutdown()
+
+**Release Tag:** public
+
+Shuts down the PostHog instance and ensures all events are sent.
+Call shutdown() once before the process exits to ensure that all events have been sent and all promises have resolved. Do not use this function if you intend to keep using this PostHog instance after calling it. Use flush() for per-request cleanup instead.
+
+### Parameters
+
+- **`shutdownTimeoutMs?`** (`number`) - Maximum time to wait for shutdown in milliseconds
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// shutdown before process exit
+process.on('SIGINT', async () => {
+  await posthog.shutdown()
+  process.exit(0)
+})
+```
+
+---
+
+### Identification methods
+
+#### alias()
+
+**Release Tag:** public
+
+Create an alias to link two distinct IDs together.
+
+### Parameters
+
+- **`data`** (`{
+        distinctId: string;
+        alias: string;
+        disableGeoip?: boolean;
+    }`) - The alias data containing distinctId and alias
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+// Link an anonymous user to an identified user
+client.alias({
+  distinctId: 'anonymous_123',
+  alias: 'user_456'
+})
+```
+
+---
+
+#### aliasImmediate()
+
+**Release Tag:** public
+
+Create an alias to link two distinct IDs together immediately (synchronously).
+
+### Parameters
+
+- **`data`** (`{
+        distinctId: string;
+        alias: string;
+        disableGeoip?: boolean;
+    }`) - The alias data containing distinctId and alias
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Link an anonymous user to an identified user immediately
+await client.aliasImmediate({
+  distinctId: 'anonymous_123',
+  alias: 'user_456'
+})
+```
+
+---
+
+#### getCustomUserAgent()
+
+**Release Tag:** public
+
+Get the custom user agent string for this client.
+
+### Returns
+
+- `string`
+
+### Examples
+
+```node
+// Get user agent
+const userAgent = client.getCustomUserAgent()
+// Returns: "posthog-node/5.7.0"
+```
+
+---
+
+#### groupIdentify()
+
+**Release Tag:** public
+
+Create or update a group and its properties.
+
+### Parameters
+
+- **`{ groupType, groupKey, properties, distinctId, disableGeoip }`** (`any`)
+- **`input`** (`GroupIdentifyMessage`)
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Create a company group
+
+```node
+// Create a company group
+client.groupIdentify({
+  groupType: 'company',
+  groupKey: 'acme-corp',
+  properties: {
+    name: 'Acme Corporation',
+    industry: 'Technology',
+    employee_count: 500
+  },
+  distinctId: 'user_123'
+})
+```
+
+#### Update organization properties
+
+```node
+// Update organization properties
+client.groupIdentify({
+  groupType: 'organization',
+  groupKey: 'org-456',
+  properties: {
+    plan: 'enterprise',
+    region: 'US-West'
+  }
+})
+```
+
+---
+
+#### groupIdentifyImmediate()
+
+**Release Tag:** public
+
+Create or update a group and its properties immediately (synchronously).
+
+### Parameters
+
+- **`{ groupType, groupKey, properties, distinctId, disableGeoip, }`** (`any`)
+- **`input`** (`GroupIdentifyMessage`)
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Immediately create or update a company group
+await client.groupIdentifyImmediate({
+  groupType: 'company',
+  groupKey: 'acme-corp',
+  properties: {
+    name: 'Acme Corporation',
+    industry: 'Technology',
+    employee_count: 500
+  }
+})
+```
+
+---
+
+#### identify()
+
+**Release Tag:** public
+
+Identify a user and set their properties.
+
+### Parameters
+
+- **`{ distinctId, properties, disableGeoip }`** (`any`)
+- **`input`** (`IdentifyMessage`)
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Basic identify with properties
+
+```node
+// Basic identify with properties
+client.identify({
+  distinctId: 'user_123',
+  properties: {
+    name: 'John Doe',
+    email: 'john@example.com',
+    plan: 'premium'
+  }
+})
+```
+
+#### Using $set and $set_once
+
+```node
+// Using $set and $set_once
+client.identify({
+  distinctId: 'user_123',
+  properties: {
+    $set: { name: 'John Doe', email: 'john@example.com' },
+    $set_once: { first_login: new Date().toISOString() }
+    $anon_distinct_id: 'anonymous_user_456'
+  }
+})
+```
+
+---
+
+#### identifyImmediate()
+
+**Release Tag:** public
+
+Identify a user and set their properties immediately (synchronously).
+
+### Parameters
+
+- **`{ distinctId, properties, disableGeoip }`** (`any`)
+- **`input`** (`IdentifyMessage`)
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Basic immediate identify
+await client.identifyImmediate({
+  distinctId: 'user_123',
+  properties: {
+    name: 'John Doe',
+    email: 'john@example.com'
+  }
+})
+```
+
+---
+
+#### setPersonProperties()
+
+**Release Tag:** public
+
+Set properties on a person profile.
+
+### Parameters
+
+- **`{ distinctId, properties, propertiesOnce }`** (`any`)
+- **`input`** (`SetPersonPropertiesMessage`)
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+client.setPersonProperties({
+  distinctId: 'user_123',
+  properties: { plan: 'premium' },
+  propertiesOnce: { first_seen: '2026-06-15' }
+})
+```
+
+---
+
+#### unsetPersonProperties()
+
+**Release Tag:** public
+
+Remove properties from a person profile.
+
+### Parameters
+
+- **`{ distinctId, properties }`** (`any`)
+- **`input`** (`UnsetPersonPropertiesMessage`)
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+client.unsetPersonProperties({
+  distinctId: 'user_123',
+  properties: ['plan', 'email']
+})
+```
+
+---
+
+### Capture methods
+
+#### capture()
+
+**Release Tag:** public
+
+Capture an event manually.
+
+### Parameters
+
+- **`props`** (`EventMessage`) - The event properties
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+// Basic capture
+client.capture({
+  distinctId: 'user_123',
+  event: 'button_clicked',
+  properties: { button_color: 'red' }
+})
+```
+
+---
+
+#### captureImmediate()
+
+**Release Tag:** public
+
+Capture an event immediately (synchronously).
+
+### Parameters
+
+- **`props`** (`EventMessage`) - The event properties
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+#### Basic immediate capture
+
+```node
+// Basic immediate capture
+await client.captureImmediate({
+  distinctId: 'user_123',
+  event: 'button_clicked',
+  properties: { button_color: 'red' }
+})
+```
+
+#### With feature flags
+
+```node
+// With feature flags
+await client.captureImmediate({
+  distinctId: 'user_123',
+  event: 'user_action',
+  sendFeatureFlags: true
+})
+```
+
+#### With custom feature flags options
+
+```node
+// With custom feature flags options
+await client.captureImmediate({
+  distinctId: 'user_123',
+  event: 'user_action',
+  sendFeatureFlags: {
+    onlyEvaluateLocally: true,
+    personProperties: { plan: 'premium' },
+    groupProperties: { org: { tier: 'enterprise' } }
+    flagKeys: ['flag1', 'flag2']
+  }
+})
+```
+
+---
+
+### Error tracking methods
+
+#### captureException()
+
+**Release Tag:** public
+
+Capture an error exception as an event.
+
+### Parameters
+
+- **`error`** (`unknown`) - The error to capture
+- **`distinctId?`** (`string`) - Optional user distinct ID
+- **`additionalProperties?`** (`Record<string | number, any>`) - Optional additional properties to include
+- **`uuid?`** (`EventMessage['uuid']`) - Optional event UUID
+- **`flags?`** (`FeatureFlagEvaluations`) - Optional `FeatureFlagEvaluations` snapshot to attach the same flag context as your other events
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Capture an error with user ID
+
+```node
+// Capture an error with user ID
+try {
+  // Some risky operation
+  riskyOperation()
+} catch (error) {
+  client.captureException(error, 'user_123')
+}
+```
+
+#### Capture with additional properties
+
+```node
+// Capture with additional properties
+try {
+  apiCall()
+} catch (error) {
+  client.captureException(error, 'user_123', {
+    endpoint: '/api/users',
+    method: 'POST',
+    status_code: 500
+  })
+}
+```
+
+---
+
+#### captureExceptionImmediate()
+
+**Release Tag:** public
+
+Capture an error exception as an event immediately (synchronously).
+
+### Parameters
+
+- **`error`** (`unknown`) - The error to capture
+- **`distinctId?`** (`string`) - Optional user distinct ID
+- **`additionalProperties?`** (`Record<string | number, any>`) - Optional additional properties to include
+- **`flags?`** (`FeatureFlagEvaluations`) - Optional `FeatureFlagEvaluations` snapshot to attach the same flag context as your other events
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+#### Capture an error immediately with user ID
+
+```node
+// Capture an error immediately with user ID
+try {
+  // Some risky operation
+  riskyOperation()
+} catch (error) {
+  await client.captureExceptionImmediate(error, 'user_123')
+}
+```
+
+#### Capture with additional properties
+
+```node
+// Capture with additional properties
+try {
+  apiCall()
+} catch (error) {
+  await client.captureExceptionImmediate(error, 'user_123', {
+    endpoint: '/api/users',
+    method: 'POST',
+    status_code: 500
+  })
+}
+```
+
+---
+
+### Privacy methods
+
+#### disable()
+
+**Release Tag:** public
+
+Disable the PostHog client (opt-out).
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Disable client
+await client.disable()
+// Client is now disabled and will not capture events
+```
+
+---
+
+#### enable()
+
+**Release Tag:** public
+
+Enable the PostHog client (opt-in).
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Enable client
+await client.enable()
+// Client is now enabled and will capture events
+```
+
+---
+
+### Feature flags methods
+
+#### evaluateFlags()
+
+**Release Tag:** public
+
+Evaluate all feature flags for a user in a single call and return a  snapshot. Branch on `.isEnabled()` / `.getFlag()`, then pass the same snapshot to `capture()` via the `flags` option so the captured event carries the exact flag values the code branched on.
+Prefer this over repeated `isFeatureEnabled()` / `getFeatureFlag()` calls and over `capture({ sendFeatureFlags: true })` — it consolidates flag evaluation into a single `/flags` request per incoming request.
+**Local evaluation is transparent.** When the poller can resolve a flag from cached definitions, no network call is made and the snapshot's `$feature_flag_called` events are tagged `locally_evaluated: true`.
+**Trim the request.** Pass `flagKeys` to scope the underlying `/flags` request to a subset of flags — useful when you only need a few flags and want to reduce the response payload.
+**Trim the event payload.** Use `flags.only([...])` or `flags.onlyAccessed()` to filter which flags get attached to a captured event without re-fetching.
+
+### Parameters
+
+- **`options?`** (`AllFlagsOptions`) - Optional configuration for flag evaluation. Supports the same fields as `getAllFlags()`, including `flagKeys` to scope the `/flags` request.
+
+### Returns
+
+- `Promise<FeatureFlagEvaluations>`
+
+### Examples
+
+#### 
+
+```node
+Basic usage:
+
+const flags = await client.evaluateFlags('user_123', {
+  personProperties: { plan: 'enterprise' },
+})
+if (flags.isEnabled('new-dashboard')) {
+  renderNewDashboard()
+}
+client.capture({ distinctId: 'user_123', event: 'page_viewed', flags })
+```
+
+#### 
+
+```node
+Scope the  request to specific keys:
+
+const flags = await client.evaluateFlags('user_123', {
+  flagKeys: ['new-dashboard', 'checkout-flow'],
+  personProperties: { plan: 'enterprise' },
+})
+```
+
+#### 
+
+```node
+Attach only the flags the developer actually checked:
+
+const flags = await client.evaluateFlags('user_123')
+if (flags.isEnabled('new-dashboard')) { ... }
+client.capture({ distinctId: 'user_123', event: 'page_viewed', flags: flags.onlyAccessed() })
+```
+
+#### 
+
+```node
+Use  to avoid repeating the distinctId:
+
+await client.withContext({ distinctId: 'user_123' }, async () => {
+  const flags = await client.evaluateFlags()
+  if (flags.isEnabled('new-dashboard')) { ... }
+  client.capture({ event: 'page_viewed', flags })
+})
+```
+
+---
+
+#### getAllFlags()
+
+**Release Tag:** public
+
+Get all feature flag values for a specific user.
+
+### Parameters
+
+- **`options?`** (`AllFlagsOptions`) - Optional configuration for flag evaluation
+
+### Returns
+
+- `Promise<Record<string, FeatureFlagValue>>`
+
+### Examples
+
+#### Get all flags for a user
+
+```node
+// Get all flags for a user
+const allFlags = await client.getAllFlags('user_123')
+console.log('User flags:', allFlags)
+// Output: { 'flag-1': 'variant-a', 'flag-2': false, 'flag-3': 'variant-b' }
+```
+
+#### With specific flag keys
+
+```node
+// With specific flag keys
+const specificFlags = await client.getAllFlags('user_123', {
+  flagKeys: ['flag-1', 'flag-2']
+})
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const orgFlags = await client.getAllFlags('user_123', {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' }
+})
+```
+
+---
+
+#### getAllFlagsAndPayloads()
+
+**Release Tag:** public
+
+Get all feature flag values and payloads for a specific user.
+
+### Parameters
+
+- **`options?`** (`AllFlagsOptions`) - Optional configuration for flag evaluation
+
+### Returns
+
+- `Promise<PostHogFlagsAndPayloadsResponse>`
+
+### Examples
+
+#### Get all flags and payloads for a user
+
+```node
+// Get all flags and payloads for a user
+const result = await client.getAllFlagsAndPayloads('user_123')
+console.log('Flags:', result.featureFlags)
+console.log('Payloads:', result.featureFlagPayloads)
+```
+
+#### With specific flag keys
+
+```node
+// With specific flag keys
+const result = await client.getAllFlagsAndPayloads('user_123', {
+  flagKeys: ['flag-1', 'flag-2']
+})
+```
+
+#### Only evaluate locally
+
+```node
+// Only evaluate locally
+const result = await client.getAllFlagsAndPayloads('user_123', {
+  onlyEvaluateLocally: true
+})
+```
+
+---
+
+#### getFeatureFlag()
+
+**Release Tag:** deprecated
+
+Get the value of a feature flag for a specific user.
+
+### Parameters
+
+- **`key`** (`string`) - The feature flag key
+- **`distinctId`** (`string`) - The user's distinct ID
+- **`options?`** (`{
+        groups?: Record<string, string>;
+        personProperties?: Record<string, string>;
+        groupProperties?: Record<string, Record<string, string>>;
+        onlyEvaluateLocally?: boolean;
+        sendFeatureFlagEvents?: boolean;
+        disableGeoip?: boolean;
+    }`) - Optional configuration for flag evaluation
+
+### Returns
+
+**Union of:**
+- `Promise<FeatureFlagValue`
+- `undefined>`
+
+### Examples
+
+#### Basic feature flag check
+
+```node
+// Basic feature flag check
+const flagValue = await client.getFeatureFlag('new-feature', 'user_123')
+if (flagValue === 'variant-a') {
+  // Show variant A
+} else if (flagValue === 'variant-b') {
+  // Show variant B
+} else {
+  // Flag is disabled or not found
+}
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const flagValue = await client.getFeatureFlag('org-feature', 'user_123', {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' },
+  groupProperties: { organization: { tier: 'premium' } }
+})
+```
+
+#### Only evaluate locally
+
+```node
+// Only evaluate locally
+const flagValue = await client.getFeatureFlag('local-flag', 'user_123', {
+  onlyEvaluateLocally: true
+})
+```
+
+---
+
+#### getFeatureFlagPayload()
+
+**Release Tag:** deprecated
+
+Get the payload for a feature flag.
+
+### Parameters
+
+- **`key`** (`string`) - The feature flag key
+- **`distinctId`** (`string`) - The user's distinct ID
+- **`matchValue?`** (`FeatureFlagValue`) - Optional match value to get payload for
+- **`options?`** (`{
+        groups?: Record<string, string>;
+        personProperties?: Record<string, string>;
+        groupProperties?: Record<string, Record<string, string>>;
+        onlyEvaluateLocally?: boolean;
+        sendFeatureFlagEvents?: boolean;
+        disableGeoip?: boolean;
+    }`) - Optional configuration for flag evaluation
+
+### Returns
+
+**Union of:**
+- `Promise<JsonType`
+- `undefined>`
+
+### Examples
+
+#### Get payload for a feature flag
+
+```node
+// Get payload for a feature flag
+const payload = await client.getFeatureFlagPayload('flag-key', 'user_123')
+if (payload) {
+  console.log('Flag payload:', payload)
+}
+```
+
+#### Get payload with specific match value
+
+```node
+// Get payload with specific match value
+const payload = await client.getFeatureFlagPayload('flag-key', 'user_123', 'variant-a')
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const payload = await client.getFeatureFlagPayload('org-flag', 'user_123', undefined, {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' }
+})
+```
+
+---
+
+#### getFeatureFlagResult()
+
+**Release Tag:** public
+
+Get the result of evaluating a feature flag, including its value and payload. This is more efficient than calling getFeatureFlag and getFeatureFlagPayload separately when you need both.
+
+### Parameters
+
+- **`key`** (`string`) - The feature flag key
+- **`options?`** (`FlagEvaluationOptions`) - Optional configuration for flag evaluation
+
+### Returns
+
+**Union of:**
+- `Promise<FeatureFlagResult`
+- `undefined>`
+
+### Examples
+
+#### Get flag result
+
+```node
+// Get flag result
+const result = await client.getFeatureFlagResult('my-flag', 'user_123')
+if (result) {
+  console.log('Flag enabled:', result.enabled)
+  console.log('Variant:', result.variant)
+  console.log('Payload:', result.payload)
+}
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const result = await client.getFeatureFlagResult('org-feature', 'user_123', {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' }
+})
+```
+
+---
+
+#### getRemoteConfigPayload()
+
+**Release Tag:** public
+
+Get the remote config payload for a feature flag.
+
+### Parameters
+
+- **`flagKey`** (`string`) - The feature flag key
+
+### Returns
+
+**Union of:**
+- `Promise<JsonType`
+- `undefined>`
+
+### Examples
+
+```node
+// Get remote config payload
+const payload = await client.getRemoteConfigPayload('flag-key')
+if (payload) {
+  console.log('Remote config payload:', payload)
+}
+```
+
+---
+
+#### isFeatureEnabled()
+
+**Release Tag:** deprecated
+
+Check if a feature flag is enabled for a specific user.
+
+### Parameters
+
+- **`key`** (`string`) - The feature flag key
+- **`distinctId`** (`string`) - The user's distinct ID
+- **`options?`** (`{
+        groups?: Record<string, string>;
+        personProperties?: Record<string, string>;
+        groupProperties?: Record<string, Record<string, string>>;
+        onlyEvaluateLocally?: boolean;
+        sendFeatureFlagEvents?: boolean;
+        disableGeoip?: boolean;
+    }`) - Optional configuration for flag evaluation
+
+### Returns
+
+**Union of:**
+- `Promise<boolean`
+- `undefined>`
+
+### Examples
+
+#### Basic feature flag check
+
+```node
+// Basic feature flag check
+const isEnabled = await client.isFeatureEnabled('new-feature', 'user_123')
+if (isEnabled) {
+  // Feature is enabled
+  console.log('New feature is active')
+} else {
+  // Feature is disabled
+  console.log('New feature is not active')
+}
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const isEnabled = await client.isFeatureEnabled('org-feature', 'user_123', {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' }
+})
+```
+
+---
+
+#### isLocalEvaluationReady()
+
+**Release Tag:** public
+
+Check if local evaluation of feature flags is ready.
+
+### Returns
+
+- `boolean`
+
+### Examples
+
+```node
+// Check if ready
+if (client.isLocalEvaluationReady()) {
+  // Local evaluation is ready, can evaluate flags locally
+  const flag = await client.getFeatureFlag('flag-key', 'user_123')
+} else {
+  // Local evaluation not ready, will use remote evaluation
+  const flag = await client.getFeatureFlag('flag-key', 'user_123')
+}
+```
+
+---
+
+#### overrideFeatureFlags()
+
+**Release Tag:** public
+
+Override feature flags locally. Useful for testing and local development. Overridden flags take precedence over both local evaluation and remote evaluation.
+
+### Parameters
+
+- **`overrides`** (`OverrideFeatureFlagsOptions`) - Flag overrides configuration
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+// Clear all overrides
+client.overrideFeatureFlags(false)
+
+// Enable a list of flags (sets them to true)
+client.overrideFeatureFlags(['flag-a', 'flag-b'])
+
+// Set specific flag values/variants
+client.overrideFeatureFlags({ 'my-flag': 'variant-a', 'other-flag': true })
+
+// Set both flags and payloads
+client.overrideFeatureFlags({
+  flags: { 'my-flag': 'variant-a' },
+  payloads: { 'my-flag': { discount: 20 } }
+})
+```
+
+---
+
+#### reloadFeatureFlags()
+
+**Release Tag:** public
+
+Reload feature flag definitions from the server for local evaluation.
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+#### Force reload of feature flags
+
+```node
+// Force reload of feature flags
+await client.reloadFeatureFlags()
+console.log('Feature flags reloaded')
+```
+
+#### Reload before checking a specific flag
+
+```node
+// Reload before checking a specific flag
+await client.reloadFeatureFlags()
+const flag = await client.getFeatureFlag('flag-key', 'user_123')
+```
+
+---
+
+#### waitForLocalEvaluationReady()
+
+**Release Tag:** public
+
+Wait for local evaluation of feature flags to be ready.
+
+### Parameters
+
+- **`timeoutMs?`** (`number`) - Timeout in milliseconds (default: 30000)
+
+### Returns
+
+- `Promise<boolean>`
+
+### Examples
+
+#### Wait for local evaluation
+
+```node
+// Wait for local evaluation
+const isReady = await client.waitForLocalEvaluationReady()
+if (isReady) {
+  console.log('Local evaluation is ready')
+} else {
+  console.log('Local evaluation timed out')
+}
+```
+
+#### Wait with custom timeout
+
+```node
+// Wait with custom timeout
+const isReady = await client.waitForLocalEvaluationReady(10000) // 10 seconds
+```
+
+---
+
+### Context methods
+
+#### getContext()
+
+**Release Tag:** public
+
+Get the current context data.
+
+### Returns
+
+**Union of:**
+- `ContextData`
+- `undefined`
+
+### Examples
+
+```node
+// Get current context within a withContext block
+posthog.withContext({ distinctId: 'user_123' }, () => {
+  const context = posthog.getContext()
+  console.log(context?.distinctId) // 'user_123'
+})
+```
+
+---
+
+#### withContext()
+
+**Release Tag:** public
+
+Run a function with specific context that will be applied to all events captured within that context. It propagates the context to all subsequent calls down the call stack. Context properties like tags and sessionId will be automatically attached to all events. By default, nested contexts inherit from parent contexts. Use `{ fresh: true }` to start with a clean context.
+
+### Parameters
+
+- **`data`** (`Partial<ContextData>`) - Context data to apply (sessionId, distinctId, properties, enableExceptionAutocapture)
+- **`fn`** (`() => T`) - Function to run with the context
+- **`options?`** (`ContextOptions`) - Context options (fresh: true to start with clean context instead of inheriting)
+
+### Returns
+
+- `T`
+
+### Examples
+
+```node
+posthog.withContext({ distinctId: 'user_123' }, () => {
+  posthog.capture({ event: 'button clicked' })
+})
+```
+
+---

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ static/studio
 dist
 .turbo
 .sanity
+.env

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
     "cobe": "^2.0.1",
+    "posthog-js": "^1.404.1",
     "studio": "workspace:1.0.0"
   }
 }

--- a/apps/web/src/lib/button-link.svelte
+++ b/apps/web/src/lib/button-link.svelte
@@ -7,6 +7,7 @@
     href = "",
     target = "",
     rel = "",
+    onclick,
     children,
   }: {
     variant?: "primary" | "secondary"
@@ -14,25 +15,28 @@
     href?: string
     target?: string
     rel?: string
+    onclick?: (event: MouseEvent) => void
     children?: Snippet
   } = $props()
 </script>
 
 {#if variant === "primary"}
   <a
-    class="flex items-center justify-start rounded-xl bg-white py-4 px-6 font-bold text-black ring-0 ring-white ring-offset-default-900 transition duration-200 ease-in-out hover:bg-gray-100 hover:ring-2 hover:ring-offset-4 {className}"
+    class="ring-offset-default-900 flex items-center justify-start rounded-xl bg-white px-6 py-4 font-bold text-black ring-0 ring-white transition duration-200 ease-in-out hover:bg-gray-100 hover:ring-2 hover:ring-offset-4 {className}"
     {href}
     {rel}
     {target}
+    {onclick}
   >
     {@render children?.()}
   </a>
 {:else}
   <a
-    class="flex justify-start items-center transition text-white py-4 px-6 rounded-xl font-bold bg-default-700 ring-0 hover:ring-2 ring-white hover:ring-offset-4 ring-offset-default-900 ease-in-out duration-200 {className}"
+    class="bg-default-700 ring-offset-default-900 flex items-center justify-start rounded-xl px-6 py-4 font-bold text-white ring-0 ring-white transition duration-200 ease-in-out hover:ring-2 hover:ring-offset-4 {className}"
     {href}
     {rel}
     {target}
+    {onclick}
   >
     {@render children?.()}
   </a>

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -1,0 +1,14 @@
+import posthog from "posthog-js"
+import { browser } from "$app/environment"
+import { PUBLIC_POSTHOG_KEY, PUBLIC_POSTHOG_HOST } from "$env/static/public"
+
+export function initPostHog() {
+  if (!browser) return
+  posthog.init(PUBLIC_POSTHOG_KEY, {
+    api_host: PUBLIC_POSTHOG_HOST,
+    capture_pageview: false,
+    capture_exceptions: true,
+  })
+}
+
+export { posthog }

--- a/apps/web/src/lib/project-link.svelte
+++ b/apps/web/src/lib/project-link.svelte
@@ -1,11 +1,22 @@
 <script lang="ts">
   import Icon from "$lib/icon.svelte"
 
-  let { link, name }: { link: string; name: string } = $props()
+  let {
+    link,
+    name,
+    onclick,
+  }: { link: string; name: string; onclick?: (event: MouseEvent) => void } =
+    $props()
 </script>
 
 <li class="text-sm font-bold opacity-60 transition-opacity hover:opacity-100">
-  <a href={link} class="flex items-center" rel="noreferrer" target="_blank">
+  <a
+    href={link}
+    class="flex items-center"
+    rel="noreferrer"
+    target="_blank"
+    {onclick}
+  >
     <Icon --src="url('/icons/link.svg')" class="mr-1" />{name}
   </a>
 </li>

--- a/apps/web/src/lib/projects.svelte
+++ b/apps/web/src/lib/projects.svelte
@@ -3,6 +3,7 @@
   import ProjectLink from "$lib/project-link.svelte"
   import type { Snippet } from "svelte"
   import { m } from "$lib/paraglide/messages"
+  import { posthog } from "$lib/posthog"
 
   let {
     title,
@@ -51,7 +52,10 @@
       <ProjectTag name={m.tag_saas()} bgColor="bg-red-50 text-red-900" />
     {/if}
     {#if ecommerce}
-      <ProjectTag name={m.tag_ecommerce()} bgColor="bg-green-50 text-green-900" />
+      <ProjectTag
+        name={m.tag_ecommerce()}
+        bgColor="bg-green-50 text-green-900"
+      />
     {/if}
     {#if marketing}
       <ProjectTag
@@ -60,7 +64,10 @@
       />
     {/if}
     {#if openSource}
-      <ProjectTag name={m.tag_open_source()} bgColor="bg-blue-50 text-blue-900" />
+      <ProjectTag
+        name={m.tag_open_source()}
+        bgColor="bg-blue-50 text-blue-900"
+      />
     {/if}
     {#if android}
       <ProjectTag name={m.tag_android()} bgColor="bg-teal-50 text-teal-900" />
@@ -90,13 +97,37 @@
       </li>
     {/if}
     {#if githubLink}
-      <ProjectLink name="GitHub" link={githubLink} />
+      <ProjectLink
+        name="GitHub"
+        link={githubLink}
+        onclick={() =>
+          posthog.capture("project link clicked", {
+            project_title: title,
+            link_type: "github",
+          })}
+      />
     {/if}
     {#if webLink}
-      <ProjectLink name="Web" link={webLink} />
+      <ProjectLink
+        name="Web"
+        link={webLink}
+        onclick={() =>
+          posthog.capture("project link clicked", {
+            project_title: title,
+            link_type: "web",
+          })}
+      />
     {/if}
     {#if googlePlayLink}
-      <ProjectLink name="Google Play" link={googlePlayLink} />
+      <ProjectLink
+        name="Google Play"
+        link={googlePlayLink}
+        onclick={() =>
+          posthog.capture("project link clicked", {
+            project_title: title,
+            link_type: "google_play",
+          })}
+      />
     {/if}
   </ul>
 </article>

--- a/apps/web/src/lib/social-link.svelte
+++ b/apps/web/src/lib/social-link.svelte
@@ -6,11 +6,13 @@
     text,
     icon,
     class: className = "",
+    onclick,
   }: {
     href: string
     text: string
     icon: string
     class?: string
+    onclick?: (event: MouseEvent) => void
   } = $props()
 </script>
 
@@ -20,6 +22,7 @@
     class="flex items-center text-sm font-medium opacity-40 transition-opacity hover:opacity-100 {className}"
     target="_blank"
     rel="noreferrer"
+    {onclick}
   >
     <Icon class="mr-1 h-4 w-4 object-cover" --src="url({icon})" />
     {text}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -13,6 +13,9 @@
     locales,
     localizeHref,
   } from "$lib/paraglide/runtime"
+  import { onMount } from "svelte"
+  import { afterNavigate } from "$app/navigation"
+  import { initPostHog, posthog } from "$lib/posthog"
 
   let { children }: { children?: Snippet } = $props()
 
@@ -20,6 +23,16 @@
     en: "English",
     id: "Bahasa Indonesia",
   }
+
+  onMount(() => {
+    initPostHog()
+  })
+
+  afterNavigate(({ to }) => {
+    posthog.capture("$pageview", {
+      $current_url: to?.url.href ?? window.location.href,
+    })
+  })
 
   const canonicalPath = $derived(deLocalizeHref(page.url.pathname))
 
@@ -38,13 +51,17 @@
       href={`https://chrsep.dev${localizedPath(canonicalPath, locale)}`}
     />
   {/each}
-  <link rel="alternate" hreflang="x-default" href={`https://chrsep.dev${canonicalPath}`} />
+  <link
+    rel="alternate"
+    hreflang="x-default"
+    href={`https://chrsep.dev${canonicalPath}`}
+  />
 </svelte:head>
 
 <nav
-  class="fixed inset-x-0 top-0 z-10 h-12 w-full bg-default-900 bg-opacity-80 px-6 text-sm text-ink-900 backdrop-blur-lg backdrop-filter sm:h-16 sm:px-8 md:px-32 "
+  class="bg-default-900 bg-opacity-80 text-ink-900 fixed inset-x-0 top-0 z-10 h-12 w-full px-6 text-sm backdrop-blur-lg backdrop-filter sm:h-16 sm:px-8 md:px-32"
 >
-  <div class="mx-auto flex h-12 max-w-[1920px] gap-4 sm:h-16 sm:gap-8 ">
+  <div class="mx-auto flex h-12 max-w-[1920px] gap-4 sm:h-16 sm:gap-8">
     <a
       href={localizedPath("/", getLocale())}
       class="group mr-auto flex h-full items-center font-bold"
@@ -61,7 +78,7 @@
 
     <a
       href={localizeHref("/cv")}
-      class="flex h-full items-center font-medium text-ink-700 transition-colors hover:text-ink-900"
+      class="text-ink-700 hover:text-ink-900 flex h-full items-center font-medium transition-colors"
     >
       {m.nav_cv()}
     </a>
@@ -93,26 +110,26 @@
   </div>
 </nav>
 
-<main class="mt-12 min-h-screen text-ink-900 sm:mt-16">
+<main class="text-ink-900 mt-12 min-h-screen sm:mt-16">
   {@render children?.()}
 </main>
 
 <footer
-  class="mt-32 border-t border-[#ffffff0D] pb-6 pt-12 text-ink-900 sm:py-12 sm:py-16"
+  class="text-ink-900 mt-32 border-t border-[#ffffff0D] pt-12 pb-6 sm:py-12 sm:py-16"
 >
   <div
     class="mx-auto flex max-w-[1920px] flex-col px-6 sm:flex-row sm:items-end sm:px-8 md:px-32"
   >
     <div>
-      <h1 class="text-xl font-black leading-tight md:text-2xl">
+      <h1 class="text-xl leading-tight font-black md:text-2xl">
         {m.lets_work_together()}
       </h1>
-      <p class="my-4 max-w-sm text-ink-800 opacity-70 sm:mb-0">
+      <p class="text-ink-800 my-4 max-w-sm opacity-70 sm:mb-0">
         {m.footer_body()}
       </p>
       <ButtonLink
         href="mailto:hi@chrsep.dev"
-        class="group mb-4 mt-2 !inline-block w-full text-sm sm:mb-0 sm:mr-4 sm:mt-6 sm:w-auto"
+        class="group mt-2 mb-4 !inline-block w-full text-sm sm:mt-6 sm:mr-4 sm:mb-0 sm:w-auto"
       >
         {m.footer_cta()}
         <span
@@ -126,7 +143,7 @@
     <div class="mt-12 sm:ml-auto">
       <a
         href="mailto:hi@chrsep.dev"
-        class="flex items-center font-medium text-ink-900 opacity-40 transition hover:opacity-100"
+        class="text-ink-900 flex items-center font-medium opacity-40 transition hover:opacity-100"
       >
         <svg
           class="mr-3 h-4 w-4"

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -15,6 +15,7 @@
   import Seo from "$lib/seo.svelte"
   import { m } from "$lib/paraglide/messages"
   import { localizeHref } from "$lib/paraglide/runtime"
+  import { posthog } from "$lib/posthog"
 
   const globeModule = import("$lib/globe.svelte")
 </script>
@@ -22,38 +23,46 @@
 <Seo title={m.site_title()} description={m.site_description()} />
 
 <div
-  class="relative overflow-hidden hero-bg border-t border-[#ffffff0A]"
+  class="hero-bg relative overflow-hidden border-t border-[#ffffff0A]"
   in:fade={{ duration: 250 }}
 >
   <header
-    class="px-6 sm:px-8 pb-8 sm:pb-16 pt-6 sm:pt-40 md:px-32 relative z-1 max-w-[1920px] mx-auto md:h-[720px]"
+    class="relative z-1 mx-auto max-w-[1920px] px-6 pt-6 pb-8 sm:px-8 sm:pt-40 sm:pb-16 md:h-[720px] md:px-32"
   >
-    <ul class="flex mb-6 gap-4">
+    <ul class="mb-6 flex gap-4">
       <SocialLink
         text="@chrsep"
         href="https://github.com/chrsep"
         icon="/icons/github.svg"
+        onclick={() =>
+          posthog.capture("social link clicked", { platform: "github" })}
       />
       <SocialLink
         text="Chrisando"
         href="https://linkedin.com/in/chrsep"
         icon="/icons/linkedin.svg"
+        onclick={() =>
+          posthog.capture("social link clicked", { platform: "linkedin" })}
       />
       <SocialLink
         text="@_chrsep"
         href="https://twitter.com/_chrsep"
         icon="/icons/twitter.svg"
+        onclick={() =>
+          posthog.capture("social link clicked", { platform: "twitter" })}
       />
       <SocialLink
         text="@chrsep"
         href="https://stackoverflow.com/users/6656573/chrsep"
         class="hidden sm:flex"
         icon="/icons/stackoverflow.svg"
+        onclick={() =>
+          posthog.capture("social link clicked", { platform: "stackoverflow" })}
       />
     </ul>
 
-    <h1 class="text-xl sm:text-2xl max-w-md">
-      <span class="font-black text-ink-900">{m.home_hero_greeting()}</span>
+    <h1 class="max-w-md text-xl sm:text-2xl">
+      <span class="text-ink-900 font-black">{m.home_hero_greeting()}</span>
       <span class="text-ink-700">
         <!-- eslint-disable-next-line svelte/no-at-html-tags -- static, developer-authored message -->
         {@html m.home_hero_pitch()}
@@ -63,11 +72,13 @@
     <div class="mt-8">
       <ButtonLink
         href="mailto:hi@chrsep.dev"
-        class="!inline-block w-full sm:w-auto mb-4 sm:mb-0 sm:mr-2 group"
+        class="group mb-4 !inline-block w-full sm:mr-2 sm:mb-0 sm:w-auto"
+        onclick={() =>
+          posthog.capture("contact cta clicked", { location: "hero" })}
       >
         {m.lets_work_together()}
         <span
-          class="transition-transform transform mr-1 group-hover:translate-x-2 ease-in-out duration-200 ml-auto sm:ml-3"
+          class="mr-1 ml-auto transform transition-transform duration-200 ease-in-out group-hover:translate-x-2 sm:ml-3"
         >
           ->
         </span>
@@ -76,11 +87,11 @@
       <ButtonLink
         variant="secondary"
         href={localizeHref("/cv")}
-        class="!inline-block w-full sm:w-auto group"
+        class="group !inline-block w-full sm:w-auto"
       >
         {m.home_more_about_me()}
         <span
-          class="text-lg transition-transform transform mr-1 group-hover:translate-x-2 ease-in-out duration-200 ml-auto sm:ml-3"
+          class="mr-1 ml-auto transform text-lg transition-transform duration-200 ease-in-out group-hover:translate-x-2 sm:ml-3"
         >
           👨‍💻
         </span>
@@ -100,9 +111,9 @@
 
 <div class="border-t border-[#ffffff0D] pt-16">
   <article
-    class="px-6 sm:px-8 md:px-32 bg-default-900  z-1 relative max-w-[1920px] mx-auto"
+    class="bg-default-900 relative z-1 mx-auto max-w-[1920px] px-6 sm:px-8 md:px-32"
   >
-    <div class="mb-8 max-w-lg prose">
+    <div class="prose mb-8 max-w-lg">
       <h2>{m.home_projects_heading()}</h2>
       <p>
         {m.home_projects_body()}
@@ -111,7 +122,7 @@
   </article>
 
   <section
-    class="flex md:grid md:grid-cols-2 xl:grid-cols-4 overflow-auto md:px-32 sm:px-8 snap-x snap-mandatory gap-8 lg:gap-16 xl:gap-8 pb-8 max-w-[1920px] mx-auto"
+    class="mx-auto flex max-w-[1920px] snap-x snap-mandatory gap-8 overflow-auto pb-8 sm:px-8 md:grid md:grid-cols-2 md:px-32 lg:gap-16 xl:grid-cols-4 xl:gap-8"
   >
     <Project
       title="Obserfy"
@@ -213,19 +224,19 @@
     <!--      />-->
   </section>
 
-  <section class="flex items-center mt-8">
-    <div class="mx-auto relative inline-block">
+  <section class="mt-8 flex items-center">
+    <div class="relative mx-auto inline-block">
       <div
-        class="w-40 h-40 absolute bg-indigo-800 rounded-full -z-10 filter blur-3xl opacity-80"
+        class="absolute -z-10 h-40 w-40 rounded-full bg-indigo-800 opacity-80 blur-3xl filter"
       ></div>
       <div
-        class="w-40 h-40 absolute bg-blue-800 rounded-full -z-10 filter blur-3xl bottom-0 right-0 opacity-80"
+        class="absolute right-0 bottom-0 -z-10 h-40 w-40 rounded-full bg-blue-800 opacity-80 blur-3xl filter"
       ></div>
 
       <div
-        class="bg-default-700 bg-opacity-60 p-6 m-6 rounded-3xl lg:flex items-end border border-white border-opacity-10"
+        class="bg-default-700 bg-opacity-60 border-opacity-10 m-6 items-end rounded-3xl border border-white p-6 lg:flex"
       >
-        <div class="max-w-md prose prose-sm">
+        <div class="prose prose-sm max-w-md">
           <h2>{m.home_open_source_heading()}</h2>
           <p>
             {m.home_open_source_body()}
@@ -236,12 +247,13 @@
           href="https://github.com/chrsep"
           target="_blank"
           rel="noreferrer"
-          class="ml-0 lg:ml-8 !px-6 !py-4 text-xs flex-shrink-0 mt-6 w-full sm:w-auto"
+          class="mt-6 ml-0 w-full flex-shrink-0 !px-6 !py-4 text-xs sm:w-auto lg:ml-8"
+          onclick={() => posthog.capture("github cta clicked")}
         >
           {m.home_open_source_cta()}
           <Icon
             --src="url(/icons/github.svg)"
-            class={"w-4 h-4 ml-auto lg:ml-4 bg-black"}
+            class={"ml-auto h-4 w-4 bg-black lg:ml-4"}
           />
         </ButtonLink>
       </div>

--- a/apps/web/src/routes/cv/+page.svelte
+++ b/apps/web/src/routes/cv/+page.svelte
@@ -1,22 +1,28 @@
 <script lang="ts">
   import { fade } from "svelte/transition"
+  import { onMount } from "svelte"
   import Seo from "$lib/seo.svelte"
   import { m } from "$lib/paraglide/messages"
+  import { posthog } from "$lib/posthog"
+
+  onMount(() => {
+    posthog.capture("cv viewed")
+  })
 </script>
 
 <Seo title={m.cv_title()} description={m.cv_description()} />
 
 <header
-  class="sm:skew-y-4 relative block w-full skew-y-6 transform border-b border-black px-6 pb-12 pt-16 sm:pb-16 md:px-32 lg:pb-32 lg:pt-24 2xl:px-0"
+  class="relative block w-full skew-y-6 transform border-b border-black px-6 pt-16 pb-12 sm:skew-y-4 sm:pb-16 md:px-32 lg:pt-24 lg:pb-32 2xl:px-0"
   in:fade
 >
   <p
-    class="sm:-skew-y-4 relative z-10 max-w-7xl -skew-y-6 transform pb-2 font-medium text-ink-600 lg:text-lg 2xl:mx-auto"
+    class="text-ink-600 relative z-10 max-w-7xl -skew-y-6 transform pb-2 font-medium sm:-skew-y-4 lg:text-lg 2xl:mx-auto"
   >
     {m.cv_label()}
   </p>
   <h1
-    class="sm:-skew-y-4 relative z-10 max-w-7xl -skew-y-6 transform text-4xl font-black sm:text-5xl lg:text-6xl 2xl:mx-auto"
+    class="relative z-10 max-w-7xl -skew-y-6 transform text-4xl font-black sm:-skew-y-4 sm:text-5xl lg:text-6xl 2xl:mx-auto"
   >
     Chrisando Eka <br /> Pramudhita
   </h1>
@@ -25,9 +31,11 @@
     class="absolute inset-0 flex items-center justify-center overflow-hidden"
   >
     <div
-      class="md:right-1/6 absolute top-[300px] flex animate-spin-slow blur-3xl filter sm:top-[300px] lg:top-[490px]"
+      class="animate-spin-slow absolute top-[300px] flex blur-3xl filter sm:top-[300px] md:right-1/6 lg:top-[490px]"
     >
-      <div class="h-[800px] w-[800px] rounded-full bg-green-700 opacity-90"></div>
+      <div
+        class="h-[800px] w-[800px] rounded-full bg-green-700 opacity-90"
+      ></div>
       <div
         class="-ml-[600px] h-[800px] w-[800px] rounded-full bg-blue-700 opacity-90"
       ></div>

--- a/apps/web/src/routes/resources/vibecoding-demo/+page.svelte
+++ b/apps/web/src/routes/resources/vibecoding-demo/+page.svelte
@@ -5,6 +5,7 @@
   import AgentSessionViewer from "$lib/vibecoding/agent-sessions/agent-session-viewer.svelte"
   import Seo from "$lib/seo.svelte"
   import { m } from "$lib/paraglide/messages"
+  import { posthog } from "$lib/posthog"
 
   type TabId = "links" | "agent-sessions" | "summary" | "qa"
 
@@ -138,6 +139,7 @@
   let activeSectionId: string | null = null
 
   function selectTab(tabId: TabId, moveFocus = false) {
+    posthog.capture("vibecoding tab switched", { tab: tabId })
     activeTab = tabId
     if (tabId === "agent-sessions") agentSessionsVisited = true
 
@@ -237,6 +239,7 @@
         href="https://vibecoding-workshop-gilt.vercel.app/"
         target="_blank"
         rel="noreferrer"
+        onclick={() => posthog.capture("vibecoding presentation opened")}
       >
         {m.vibe_open_presentation()}
         <span class="ml-1.5" aria-hidden="true">↗</span>
@@ -246,6 +249,7 @@
         class="text-ink-700 hover:text-ink-900 inline-flex min-h-11 items-center text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
         href="/resources/vibecoding-workshop.pdf"
         download="vibecoding-workshop.pdf"
+        onclick={() => posthog.capture("vibecoding pdf downloaded")}
       >
         {m.vibe_download()}
         <span class="ml-1.5" aria-hidden="true">↓</span>
@@ -401,6 +405,12 @@
                     href={link.href}
                     target="_blank"
                     rel="noreferrer"
+                    onclick={() =>
+                      posthog.capture("vibecoding resource link clicked", {
+                        link_label: link.label,
+                        link_group: group.id,
+                        link_href: link.href,
+                      })}
                   >
                     <span class="min-w-0">
                       <span class="text-ink-900 block font-semibold">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       cobe:
         specifier: ^2.0.1
         version: 2.0.1
+      posthog-js:
+        specifier: ^1.404.1
+        version: 1.404.1
       studio:
         specifier: workspace:1.0.0
         version: link:../studio
@@ -133,8 +136,6 @@ importers:
       vitest:
         specifier: ^4.1.0
         version: 4.1.10(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
-
-  apps/web/src/lib/paraglide/messages: {}
 
   packages/cv: {}
 
@@ -2227,6 +2228,12 @@ packages:
     resolution: {integrity: sha512-djfIGU9n6DRrunlvj2nIDAp17URo/nA4jSXGvf+Gupx8NLLy9fmJBZ3GL8yhqn9lSVc+cKCharjOa3aOBnWbRw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
+  '@posthog/core@1.43.1':
+    resolution: {integrity: sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==}
+
+  '@posthog/types@1.397.0':
+    resolution: {integrity: sha512-Pa7FtsBo3V0XrhY4y8Xquwp8U07syuZ2IGQdlsRyxhz0yejQLceFjI58UssCXE5zDCDj3km5l7H3ufD6rHChCg==}
+
   '@rexxars/react-json-inspector@9.0.1':
     resolution: {integrity: sha512-4uZ4RnrVoOGOShIKKcPoF+qhwDCZJsPPqyoEoW/8HRdzNknN9Q2yhlbEgTX1lMZunF1fv7iHzAs+n1vgIgfg/g==}
     peerDependencies:
@@ -3670,6 +3677,9 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -4156,6 +4166,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -5432,9 +5445,20 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.404.1:
+    resolution: {integrity: sha512-ck/HOMKuZ6yefUk5OX+h2s9mUWBsnu0mGDUAWjIwAmQQrloZPShzOhOWuEuZQuMnCKORBFRVGsBAuzsl66cBJA==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -5549,6 +5573,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -6639,6 +6666,9 @@ packages:
 
   web-vitals@5.2.0:
     resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -8952,6 +8982,12 @@ snapshots:
 
   '@portabletext/types@4.0.2': {}
 
+  '@posthog/core@1.43.1':
+    dependencies:
+      '@posthog/types': 1.397.0
+
+  '@posthog/types@1.397.0': {}
+
   '@rexxars/react-json-inspector@9.0.1(react@19.2.6)':
     dependencies:
       debounce: 1.0.0
@@ -10597,6 +10633,8 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
 
+  core-js@3.49.0: {}
+
   core-util-is@1.0.3: {}
 
   crelt@1.0.6: {}
@@ -11264,6 +11302,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.4.8: {}
 
   figures@6.1.0:
     dependencies:
@@ -12512,7 +12552,22 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.404.1:
+    dependencies:
+      '@posthog/core': 1.43.1
+      '@posthog/types': 1.397.0
+      core-js: 3.49.0
+      dompurify: 3.4.5
+      fflate: 0.4.8
+      preact: 10.29.7
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
   powershell-utils@0.1.0: {}
+
+  preact@10.29.7: {}
 
   prelude-ls@1.2.1: {}
 
@@ -12572,6 +12627,8 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -13856,6 +13913,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   web-vitals@5.2.0: {}
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/posthog-setup-report.md
+++ b/posthog-setup-report.md
@@ -1,0 +1,40 @@
+# PostHog post-wizard report
+
+The wizard has completed a PostHog analytics integration for **chrsep.dev**, a fully prerendered static SvelteKit portfolio site. Because the site has no server-side API routes (all pages use `prerender = true`), the integration uses **posthog-js** (the browser SDK) rather than posthog-node. PostHog is initialized in the root layout on mount and tracks page navigations via SvelteKit's `afterNavigate` hook. Exception autocapture is enabled globally. Individual user actions are tracked with targeted `capture()` calls in each page component.
+
+## Events instrumented
+
+| Event name | Description | File |
+|---|---|---|
+| `$pageview` | Fired on every client-side navigation via `afterNavigate` | `apps/web/src/routes/+layout.svelte` |
+| `contact cta clicked` | User clicked a "Let's work together" email CTA (hero section) | `apps/web/src/routes/+page.svelte` |
+| `social link clicked` | User clicked a social link; `platform` property identifies which one | `apps/web/src/routes/+page.svelte` |
+| `project link clicked` | User clicked a project GitHub/web link; `project_title` and `link_type` properties | `apps/web/src/lib/projects.svelte` |
+| `github cta clicked` | User clicked the "View GitHub" CTA in the open-source section | `apps/web/src/routes/+page.svelte` |
+| `cv viewed` | User mounted the CV page | `apps/web/src/routes/cv/+page.svelte` |
+| `vibecoding tab switched` | User switched resource tabs; `tab` property identifies which tab | `apps/web/src/routes/resources/vibecoding-demo/+page.svelte` |
+| `vibecoding resource link clicked` | User clicked a resource link; `link_label`, `link_group`, `link_href` properties | `apps/web/src/routes/resources/vibecoding-demo/+page.svelte` |
+| `vibecoding pdf downloaded` | User clicked the workshop PDF download button | `apps/web/src/routes/resources/vibecoding-demo/+page.svelte` |
+| `vibecoding presentation opened` | User opened the vibecoding workshop presentation in a new tab | `apps/web/src/routes/resources/vibecoding-demo/+page.svelte` |
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+- **Dashboard**: [Analytics basics (wizard)](https://eu.posthog.com/project/228051/dashboard/834938)
+- [Pageviews over time](https://eu.posthog.com/project/228051/insights/kEiiO7te)
+- [Contact CTA clicks](https://eu.posthog.com/project/228051/insights/7wv9UXlJ)
+- [Social link clicks by platform](https://eu.posthog.com/project/228051/insights/3weMYzb4)
+- [Project link clicks by project](https://eu.posthog.com/project/228051/insights/TnsMStRA)
+- [Vibecoding engagement funnel](https://eu.posthog.com/project/228051/insights/A89tWJMz)
+
+## Verify before merging
+
+- [ ] Run a full production build (`pnpm build` in `apps/web`) and fix any lint or type errors introduced by the generated code.
+- [ ] Run the test suite — call sites that were rewritten or instrumented may need updated mocks or fixtures.
+- [ ] Add `PUBLIC_POSTHOG_KEY` and `PUBLIC_POSTHOG_HOST` to `.env.example` and any monorepo/bootstrap scripts so collaborators know what to set.
+- [ ] Wire source-map upload (`posthog-cli sourcemap` or your bundler's upload step) into CI so production stack traces de-minify.
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.


### PR DESCRIPTION
## What changed

Adds PostHog (browser SDK, `posthog-js`) to the SvelteKit web app. The site is fully prerendered with no server routes, so the client-side SDK is the right fit — it complements the existing Cloudflare Web Analytics beacon (traffic stats) with product-level event tracking.

- **`apps/web/src/lib/posthog.ts`** — init helper reading `PUBLIC_POSTHOG_KEY` / `PUBLIC_POSTHOG_HOST` from `$env/static/public`; manual pageview mode, exception autocapture on
- **`+layout.svelte`** — initializes PostHog on mount, captures `$pageview` via `afterNavigate` (covers initial load + client-side navigations)
- **Click instrumentation** — `contact cta clicked`, `social link clicked` (with `platform`), `project link clicked` (with `project_title`, `link_type`), `github cta clicked`, `cv viewed`, and vibecoding events (tab switches, resource links, PDF download, presentation opens). Link components (`button-link`, `social-link`, `project-link`) gained an optional `onclick` prop to support this
- **`posthog-setup-report.md`** — wizard-generated summary of instrumented events with links to the pre-built dashboard/insights (feel free to drop this file if you don't want it in the repo)
- **`.claude/skills/integration-javascript_node/`** — PostHog integration skill left by the wizard (repo already tracks `.claude/skills/`)
- `.env` added to `.gitignore`; keys live only in env vars, nothing hardcoded

Most of this was generated by the PostHog setup wizard; on review it had one bug — `enableExceptionAutocapture` is not a valid option in posthog-js 1.404 and failed `svelte-check`. Fixed to `capture_exceptions` (verified against the installed `@posthog/types`).

## Reviewer notes

- ⚠️ **Deploy config needed**: `$env/static/public` resolves at build time, so `PUBLIC_POSTHOG_KEY` and `PUBLIC_POSTHOG_HOST` (`https://eu.i.posthog.com`) must be set in the production build environment **before merging**, or the build will fail. Locally they're in the gitignored `apps/web/.env`.
- Several files show Tailwind class re-ordering noise from the wizard running Prettier; the functional changes are the `posthog` imports, `onclick` props, and `capture()` calls.

## Verification

- `vitest`: 15/15 pass
- `svelte-check`: 0 errors, 0 warnings
- Dev-server smoke test: PostHog initializes (persistence key + distinct_id in localStorage), client-side navigation and capture calls run with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)