### PR TITLE
configure posthog proxy host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 .turbo
 .sanity
 .env
+.env.local

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ pnpm --filter web dev
 ```
 
 PostHog is optional for local development and verification. The site skips
-analytics when `PUBLIC_POSTHOG_KEY` or `PUBLIC_POSTHOG_HOST` is absent, so a
-production credential is never required to build or test the portfolio. If a
-local environment requires both variables to exist, copy
-`apps/web/.env.example`; its values are intentionally non-production and point
-to the reserved `.invalid` domain.
+analytics when `PUBLIC_POSTHOG_KEY`, `PUBLIC_POSTHOG_HOST`, or
+`PUBLIC_POSTHOG_UI_HOST` is absent, so a production credential is never required
+to build or test the portfolio. If a local environment requires these variables
+to exist, copy `apps/web/.env.example`; its project key and ingestion host are
+intentionally non-production, with the latter pointing to the reserved
+`.invalid` domain.
 
 The main web verification commands are:
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,3 +1,4 @@
 # Optional, inert values for local builds and SEO verification only.
 PUBLIC_POSTHOG_KEY=phc_local_build
 PUBLIC_POSTHOG_HOST=https://posthog.invalid
+PUBLIC_POSTHOG_UI_HOST=https://eu.posthog.com

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -19,8 +19,9 @@ export function initPostHog(): Promise<PostHogClient | null> {
 
   const key = env.PUBLIC_POSTHOG_KEY
   const host = env.PUBLIC_POSTHOG_HOST
+  const uiHost = env.PUBLIC_POSTHOG_UI_HOST
 
-  if (!key || !host) {
+  if (!key || !host || !uiHost) {
     initializationUnavailable = true
     return Promise.resolve(null)
   }
@@ -29,6 +30,7 @@ export function initPostHog(): Promise<PostHogClient | null> {
     .then(({ default: posthog }) => {
       posthog.init(key, {
         api_host: host,
+        ui_host: uiHost,
         capture_pageview: false,
         capture_exceptions: true,
       })


### PR DESCRIPTION
## Summary

- add `PUBLIC_POSTHOG_UI_HOST` to the public environment contract
- pass the real PostHog EU UI host as `ui_host` while `api_host` uses the reverse proxy
- keep local analytics configuration inert and document the required variables
- ignore the Vercel-generated root `.env.local`

## Why

Vercel now sets `PUBLIC_POSTHOG_HOST=https://f.chrsep.dev` for production, preview, and development. Current PostHog reverse-proxy guidance recommends keeping `ui_host` pointed at the actual PostHog application so toolbar and UI links do not target the ingest proxy.

## Impact

Analytics ingestion continues through the first-party `f.chrsep.dev` proxy. After this change is deployed, PostHog UI links will continue to use `https://eu.posthog.com`. Analytics remains disabled when any required public setting is absent.

## Verification

- `pnpm --filter web check` — 0 errors and 0 warnings
- `pnpm --filter web test` — 54 tests passed
- `pnpm build` — passed
- `pnpm --filter web exec prettier --check src/lib/posthog.ts ../../README.md` — passed
- live proxy asset check: `https://f.chrsep.dev/static/array.js` returns HTTP 200
